### PR TITLE
Refactor create account with step components, implement 404 error page

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -199,6 +199,9 @@ footer {
 .logout-error {
   font-size: var(--small-text-size);
   font-weight: 600;
+  position: absolute;
+  margin-left: -35px;
+  color: var(--logout-error-red);
 }
 
 .submission-error {
@@ -283,4 +286,75 @@ footer {
   font-family: var(--header-font);
   font-size: var(--med-text-size);
   color: var(--main-color);
+}
+
+.error-page-container {
+  background-color: var(--background-light);
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+}
+
+.error-page-title {
+  font-family: var(--title-font);
+  font-size: var(--title-size);
+  font-weight: normal;
+  display: flex;
+  gap: 10px;
+  margin-top: 10vh;
+}
+
+.error-page-compass {
+  font-size: 68px;
+}
+
+@keyframes swing {
+  20% {
+    transform: rotate(110deg);
+  }
+  40% {
+    transform: rotate(40deg);
+  }
+  60% {
+    transform: rotate(90deg);
+  }
+  80% {
+    transform: rotate(68deg);
+  }
+  90% {
+    transform: rotate(72deg);
+  }
+  100% {
+    transform: rotate(70deg);
+  }
+}
+
+.error-page-swing {
+  animation-name: swing;
+  animation-duration: 5s;
+  transform-origin: center left;
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: forwards;
+}
+
+.error-page-message {
+  position: absolute;
+  bottom: 15vh;
+  font-size: var(--header-size);
+  font-family: var(--header-font);
+  font-weight: normal;
+}
+
+.error-page-link {
+  all: unset;
+  text-decoration: underline;
+  cursor: pointer;
+
+}
+
+.error-page-link:hover {
+  color: var(--background-dark);
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,12 +14,14 @@ import CreateTimetable from "./components/CreateTimetable";
 import Timetable from "./components/Timetable";
 import { Path } from "./utils/enums";
 import RootLayout from "./RootLayout";
+import ErrorPage from "./components/ErrorPage";
 
 function App() {
   const router = createBrowserRouter([
     {
       path: "/",
       element: <RootLayout />,
+      errorElement: <ErrorPage />,
       children: [
         {
           path: Path.LOGIN,

--- a/frontend/src/RootLayout.jsx
+++ b/frontend/src/RootLayout.jsx
@@ -1,8 +1,9 @@
 import { Outlet, useLocation, Link } from "react-router-dom";
 import { useEffect, useState } from "react";
 import { Path } from "./utils/enums";
-import { TAGLINE, LOGGED_IN } from "./utils/constants";
+import { TAGLINE } from "./utils/constants";
 import { useNavigate } from "react-router-dom";
+import { checkUserLoggedIn } from "./utils/functions";
 
 const RootLayout = () => {
   const navigate = useNavigate();
@@ -37,38 +38,17 @@ const RootLayout = () => {
     }
   };
 
-  const checkUserLoggedIn = async () => {
-    try {
-      const response = await fetch(
-        `${import.meta.env.VITE_BASE_URL}${Path.CHECK_CREDENTIALS}`,
-        {
-          method: "GET",
-          credentials: "include",
-        }
-      );
-
-      if (response.ok) {
-        const data = await response.json();
-        return data?.message === LOGGED_IN;
-      } else {
-        return false;
-      }
-    } catch (error) {
-      return false;
-    }
-  };
-
   useEffect(() => {
     const userAuthentication = async () => {
-      const userLoggedIn = await checkUserLoggedIn();
+      const loggedInStatus = await checkUserLoggedIn();
       const onPageWhereUserLoggedIn = location.pathname.includes("/user");
       
-      if (!userLoggedIn && onPageWhereUserLoggedIn) {
+      if (!loggedInStatus && onPageWhereUserLoggedIn) {
         navigate(Path.LOGIN);
-      } else if (userLoggedIn && !onPageWhereUserLoggedIn) {
+      } else if (loggedInStatus && !onPageWhereUserLoggedIn) {
         navigate(Path.EXPLORE);
       }
-      setIsUserLoggedIn(onPageWhereUserLoggedIn);
+      setIsUserLoggedIn(loggedInStatus);
     };
 
     userAuthentication();

--- a/frontend/src/components/CreateAccount.jsx
+++ b/frontend/src/components/CreateAccount.jsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
-import { Path } from "../utils/enums";
 import { useNavigate } from "react-router-dom";
-import { GENERIC_ERROR, DUPLICATE_EMAIL_ERROR } from "../utils/constants";
-import CreateAccountStepOne from "./CreateAccountStepOne";
+import CreateAccountStepOne from "./createAccountSteps/CreateAccountStepOne";
+import CreateAccountStepTwo from "./createAccountSteps/CreateAccountStepTwo";
+import CreateAccountStepThree from "./createAccountSteps/CreateAccountStepThree";
+import CreateAccountStepFour from "./createAccountSteps/CreateAccountStepFour";
+import CreateAccountStepFive from "./createAccountSteps/CreateAccountStepFive";
 
 const CreateAccount = () => {
   const navigate = useNavigate();
@@ -18,55 +20,35 @@ const CreateAccount = () => {
     "Learning Goal",
   ];
 
-  const [submissionError, setSubmissionError] = useState("");
-  const submitStepFive = async (event) => {
-    event.preventDefault();
-
-    try {
-      const newUser = {
-        fullName: fullName,
-        email: email,
-        password,
-        pfpUrl: "placeholder",
-        interests: [],
-        skills: [],
-        eceAreas: [],
-        desiredDesignation: "COMPUTER", // placeholder choice (between COMPUTER & ELECTRICAL)
-        learningGoal: "placeholder",
-      };
-
-      const response = await fetch(
-        `${import.meta.env.VITE_BASE_URL}${Path.CREATE_ACCOUNT}`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(newUser),
-          credentials: "include",
-        }
-      );
-
-      if (response.ok) {
-        navigate(Path.EXPLORE);
-      } else {
-        const data = await response.json();
-        setSubmissionError(
-          data.message === DUPLICATE_EMAIL_ERROR
-            ? DUPLICATE_EMAIL_ERROR
-            : GENERIC_ERROR
-        );
-      }
-    } catch (error) {
-      setSubmissionError(GENERIC_ERROR);
-      //todo: https://docs.google.com/document/d/1RS1UnB0mB0aRISJQ50sOUNsElgAoAFGHbdJiBJf_I90/edit?tab=t.0 (in PR notes)
-    }
-  };
-
   const renderPage = () => {
     switch (currentStep) {
       case 1:
-        return <CreateAccountStepOne />;
+        return (
+          <CreateAccountStepOne
+            fullName={fullName}
+            setFullName={setFullName}
+            email={email}
+            setEmail={setEmail}
+            password={password}
+            setPassword={setPassword}
+            currentStep={currentStep}
+            setCurrentStep={setCurrentStep}
+          />
+        );
+      case 2:
+        return <CreateAccountStepTwo />;
+      case 3:
+        return <CreateAccountStepThree />;
+      case 4:
+        return <CreateAccountStepFour />;
+      case 5:
+        return (
+          <CreateAccountStepFive
+            fullName={fullName}
+            email={email}
+            password={password}
+          />
+        );
       default:
         return <></>;
     }

--- a/frontend/src/components/CreateAccount.jsx
+++ b/frontend/src/components/CreateAccount.jsx
@@ -1,36 +1,15 @@
 import { useState } from "react";
-import {
-  ONE_OR_MORE_WHITESPACE_REGEX,
-  EMAIL_REGEX,
-  ALPHANUMERIC_REGEX,
-  UPPERCASE_LETTER,
-  LOWERCASE_LETTER,
-  NUMBER,
-} from "../utils/regex";
 import { Path } from "../utils/enums";
 import { useNavigate } from "react-router-dom";
-import { GENERIC_ERROR, DUPLICATE_EMAIL_ERROR, EMAIL_ERROR } from "../utils/constants";
+import { GENERIC_ERROR, DUPLICATE_EMAIL_ERROR } from "../utils/constants";
+import CreateAccountStepOne from "./CreateAccountStepOne";
 
 const CreateAccount = () => {
   const navigate = useNavigate();
   const [currentStep, setCurrentStep] = useState(1);
   const [fullName, setFullName] = useState("");
-  const [fullNameError, setFullNameError] = useState("");
   const [email, setEmail] = useState("");
-  const [emailError, setEmailError] = useState("");
   const [password, setPassword] = useState("");
-  const [passwordError, setPasswordError] = useState("");
-  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
-  const [passwordRequirementsMet, setPasswordRequirementsMet] = useState({
-    charLimit: false,
-    uppercase: false,
-    lowercase: false,
-    number: false,
-    specialChar: false,
-  });
-  const [submissionError, setSubmissionError] = useState("");
-  const FULL_NAME_ERROR = "Please enter your full name";
-  const PASSWORD_ERROR = "Please enter a valid password";
   const progressBarItems = [
     "Personal",
     "Profile Picture",
@@ -38,52 +17,15 @@ const CreateAccount = () => {
     "Degree",
     "Learning Goal",
   ];
-  const passwordRequirements = [
-    "At least 8 characters",
-    "Uppercase letter",
-    "Lowercase letter",
-    "At least 1 number",
-    "At least 1 special character",
-  ];
 
-  const handlePasswordChange = (password) => {
-    const newRequirementsStatus = { ...passwordRequirementsMet };
-    newRequirementsStatus.charLimit = password.length >= 8;
-    newRequirementsStatus.uppercase = UPPERCASE_LETTER.test(password);
-    newRequirementsStatus.lowercase = LOWERCASE_LETTER.test(password);
-    newRequirementsStatus.number = NUMBER.test(password);
-    newRequirementsStatus.specialChar =
-      !ALPHANUMERIC_REGEX.test(password) && password.length > 0;
-    setPasswordRequirementsMet(newRequirementsStatus);
-
-    setPassword(password);
-  };
-
-  const createAccount = async (event) => {
+  const [submissionError, setSubmissionError] = useState("");
+  const submitStepFive = async (event) => {
     event.preventDefault();
-    setFullNameError("");
-    setEmailError("");
-    setPasswordError("");
-    setSubmissionError("");
-
-    if (fullName.trim().split(ONE_OR_MORE_WHITESPACE_REGEX).length < 2) {
-      setFullNameError(FULL_NAME_ERROR);
-      return;
-    } else if (!EMAIL_REGEX.test(email)) {
-      setEmailError(EMAIL_ERROR);
-      return;
-    } else if (Object.values(passwordRequirementsMet).includes(false)) {
-      setPasswordError(PASSWORD_ERROR);
-      return;
-    }
-
-    const userFullName = fullName.trim();
-    const userEmail = email.trim();
 
     try {
       const newUser = {
-        fullName: userFullName,
-        email: userEmail,
+        fullName: fullName,
+        email: email,
         password,
         pfpUrl: "placeholder",
         interests: [],
@@ -101,7 +43,7 @@ const CreateAccount = () => {
             "Content-Type": "application/json",
           },
           body: JSON.stringify(newUser),
-          credentials: "include"
+          credentials: "include",
         }
       );
 
@@ -117,93 +59,22 @@ const CreateAccount = () => {
       }
     } catch (error) {
       setSubmissionError(GENERIC_ERROR);
+      //todo: https://docs.google.com/document/d/1RS1UnB0mB0aRISJQ50sOUNsElgAoAFGHbdJiBJf_I90/edit?tab=t.0 (in PR notes)
+    }
+  };
+
+  const renderPage = () => {
+    switch (currentStep) {
+      case 1:
+        return <CreateAccountStepOne />;
+      default:
+        return <></>;
     }
   };
 
   return (
     <div className="create-account">
-      <form
-        className="create-account-form"
-        onSubmit={(event) => createAccount(event)}
-      >
-        <h1 className="create-account-form-title">Get Started</h1>
-        <div className="text-input-container">
-          <input
-            type="text"
-            className="text-input"
-            placeholder="Full Name"
-            value={fullName}
-            maxLength={100}
-            onChange={(event) => setFullName(event.target.value)}
-          />
-          <span className="text-input-error">{fullNameError}</span>
-        </div>
-
-        <div className="text-input-container">
-          <input
-            type="text"
-            className="text-input"
-            placeholder="Email"
-            value={email}
-            maxLength={254}
-            onChange={(event) => setEmail(event.target.value)}
-          />
-          <span className="text-input-error">{emailError}</span>
-        </div>
-
-        <div className="password-requirements-container">
-          <ul className="password-requirements-ul">
-            {passwordRequirements.map((requirement, index) => {
-              const isRequirementMet = Object.values(passwordRequirementsMet)[
-                index
-              ];
-              return (
-                <div key={index} className="password-requirement-container">
-                  <span
-                    style={{
-                      color: isRequirementMet
-                        ? "var(--correct-green)"
-                        : "var(--error-red)",
-                    }}
-                    className="material-symbols-outlined"
-                  >
-                    {isRequirementMet ? "check_circle" : "cancel"}
-                  </span>
-                  <li className="password-requirements-li">{requirement}</li>
-                </div>
-              );
-            })}
-          </ul>
-        </div>
-
-        <div className="text-input-container">
-          <div className="create-account-password-container">
-            <input
-              type={isPasswordVisible ? "text" : "password"}
-              className="text-input"
-              placeholder="Password"
-              value={password}
-              maxLength={30}
-              onChange={(event) => handlePasswordChange(event.target.value)}
-            />
-            <span
-              className="material-symbols-outlined create-account-password-eye-icon"
-              onClick={() => setIsPasswordVisible(!isPasswordVisible)}
-            >
-              {isPasswordVisible ? "visibility_off" : "visibility"}
-            </span>
-          </div>
-          <span className="text-input-error">{passwordError}</span>
-        </div>
-
-        <div className="text-input-container">
-          <button type="submit" className="form-btn">
-            Continue
-          </button>
-          <span className="text-input-error submission-error">{submissionError}</span>
-        </div>
-
-      </form>
+      {renderPage()}
       <aside className="create-account-progress-bar-container">
         <ul className="create-account-progress-bar-content">
           {progressBarItems.map((item, index) => (

--- a/frontend/src/components/CreateAccountStepOne.jsx
+++ b/frontend/src/components/CreateAccountStepOne.jsx
@@ -1,0 +1,155 @@
+import { useState } from "react";
+import {
+  ONE_OR_MORE_WHITESPACE_REGEX,
+  EMAIL_REGEX,
+  ALPHANUMERIC_REGEX,
+  UPPERCASE_LETTER,
+  LOWERCASE_LETTER,
+  NUMBER,
+} from "../utils/regex";
+import { EMAIL_ERROR } from "../utils/constants";
+
+const CreateAccountStepOne = (props) => {
+  const [fullNameError, setFullNameError] = useState("");
+  const [emailError, setEmailError] = useState("");
+  const [passwordError, setPasswordError] = useState("");
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+  const [passwordRequirementsMet, setPasswordRequirementsMet] = useState({
+    charLimit: false,
+    uppercase: false,
+    lowercase: false,
+    number: false,
+    specialChar: false,
+  });
+  const FULL_NAME_ERROR = "Please enter your full name";
+  const PASSWORD_ERROR = "Please enter a valid password";
+
+  const passwordRequirements = [
+    "At least 8 characters",
+    "Uppercase letter",
+    "Lowercase letter",
+    "At least 1 number",
+    "At least 1 special character",
+  ];
+
+  const handlePasswordChange = (password) => {
+    const newRequirementsStatus = { ...passwordRequirementsMet };
+    newRequirementsStatus.charLimit = password.length >= 8;
+    newRequirementsStatus.uppercase = UPPERCASE_LETTER.test(password);
+    newRequirementsStatus.lowercase = LOWERCASE_LETTER.test(password);
+    newRequirementsStatus.number = NUMBER.test(password);
+    newRequirementsStatus.specialChar =
+      !ALPHANUMERIC_REGEX.test(password) && password.length > 0;
+    setPasswordRequirementsMet(newRequirementsStatus);
+
+    props.setPassword(password);
+  };
+
+  const submitStepOne = async (event) => {
+    event.preventDefault();
+    setFullNameError("");
+    setEmailError("");
+    setPasswordError("");
+    setSubmissionError("");
+
+    if (props.fullName.trim().split(ONE_OR_MORE_WHITESPACE_REGEX).length < 2) {
+      setFullNameError(FULL_NAME_ERROR);
+      return;
+    } else if (!EMAIL_REGEX.test(props.email)) {
+      setEmailError(EMAIL_ERROR);
+      return;
+    } else if (Object.values(passwordRequirementsMet).includes(false)) {
+      setPasswordError(PASSWORD_ERROR);
+      return;
+    }
+
+    props.setFullName(props.fullName.trim());
+    props.setEmail(props.email.trim());
+    props.setCurrentStep(props.currentStep++);
+  };
+
+  return (
+    <form
+      className="create-account-form"
+      onSubmit={(event) => submitStepOne(event)}
+    >
+      <h1 className="create-account-form-title">Get Started</h1>
+      <div className="text-input-container">
+        <input
+          type="text"
+          className="text-input"
+          placeholder="Full Name"
+          value={props.fullName}
+          maxLength={100}
+          onChange={(event) => props.setFullName(event.target.value)}
+        />
+        <span className="text-input-error">{fullNameError}</span>
+      </div>
+
+      <div className="text-input-container">
+        <input
+          type="text"
+          className="text-input"
+          placeholder="Email"
+          value={props.email}
+          maxLength={254}
+          onChange={(event) => props.setEmail(event.target.value)}
+        />
+        <span className="text-input-error">{emailError}</span>
+      </div>
+
+      <div className="password-requirements-container">
+        <ul className="password-requirements-ul">
+          {passwordRequirements.map((requirement, index) => {
+            const isRequirementMet = Object.values(passwordRequirementsMet)[
+              index
+            ];
+            return (
+              <div key={index} className="password-requirement-container">
+                <span
+                  style={{
+                    color: isRequirementMet
+                      ? "var(--correct-green)"
+                      : "var(--error-red)",
+                  }}
+                  className="material-symbols-outlined"
+                >
+                  {isRequirementMet ? "check_circle" : "cancel"}
+                </span>
+                <li className="password-requirements-li">{requirement}</li>
+              </div>
+            );
+          })}
+        </ul>
+      </div>
+
+      <div className="text-input-container">
+        <div className="create-account-password-container">
+          <input
+            type={isPasswordVisible ? "text" : "password"}
+            className="text-input"
+            placeholder="Password"
+            value={props.password}
+            maxLength={30}
+            onChange={(event) => handlePasswordChange(event.target.value)}
+          />
+          <span
+            className="material-symbols-outlined create-account-password-eye-icon"
+            onClick={() => setIsPasswordVisible(!isPasswordVisible)}
+          >
+            {isPasswordVisible ? "visibility_off" : "visibility"}
+          </span>
+        </div>
+        <span className="text-input-error">{passwordError}</span>
+      </div>
+
+      <div className="text-input-container">
+        <button type="submit" className="form-btn">
+          Continue
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default CreateAccountStepOne;

--- a/frontend/src/components/ErrorPage.jsx
+++ b/frontend/src/components/ErrorPage.jsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react";
+import { checkUserLoggedIn } from "../utils/functions";
+import { Link } from "react-router-dom";
+import { Path } from "../utils/enums";
+
+const ErrorPage = () => {
+  const [isUserLoggedIn, setIsUserLoggedIn] = useState(false);
+  const LOGGED_IN_PAGE = "Explore Page";
+  const LOGGED_OUT_PAGE = "Login Page";
+
+  useEffect(() => {
+    const setLoggedInStatus = async () => {
+      setIsUserLoggedIn(await checkUserLoggedIn());
+    };
+
+    setLoggedInStatus();
+  }, []);
+
+  return (
+    <div className="error-page-container">
+      <h1 className="error-page-title">
+        <div>
+          C<span className="error-page-compass">🧭</span>urse
+        </div>
+        <div className="error-page-swing">
+          C<span className="error-page-compass">🧭</span>mpass
+        </div>
+      </h1>
+      <h2 className="error-page-message">
+        Page Not Found | Return to{" "}
+        <Link
+          className="error-page-link"
+          to={isUserLoggedIn ? Path.EXPLORE : Path.LOGIN}
+        >
+          {isUserLoggedIn ? LOGGED_IN_PAGE : LOGGED_OUT_PAGE}
+        </Link>
+      </h2>
+    </div>
+  );
+};
+
+export default ErrorPage;

--- a/frontend/src/components/createAccountSteps/CreateAccountStepFive.jsx
+++ b/frontend/src/components/createAccountSteps/CreateAccountStepFive.jsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import { Path } from "../../utils/enums";
+import { GENERIC_ERROR, DUPLICATE_EMAIL_ERROR } from "../../utils/constants";
+
+const CreateAccountStepFive = (props) => {
+  const [submissionError, setSubmissionError] = useState("");
+
+  const submitStepFive = async (event) => {
+    event.preventDefault();
+    try {
+      const newUser = {
+        fullName: props.fullName,
+        email: props.email,
+        password: props.password,
+        pfpUrl: "placeholder",
+        interests: [],
+        skills: [],
+        eceAreas: [],
+        desiredDesignation: "COMPUTER", // placeholder choice (between COMPUTER & ELECTRICAL)
+        learningGoal: "placeholder",
+      };
+
+      const response = await fetch(
+        `${import.meta.env.VITE_BASE_URL}${Path.CREATE_ACCOUNT}`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(newUser),
+          credentials: "include",
+        }
+      );
+
+      if (response.ok) {
+        navigate(Path.EXPLORE);
+      } else {
+        const data = await response.json();
+        setSubmissionError(
+          data.message === DUPLICATE_EMAIL_ERROR
+            ? DUPLICATE_EMAIL_ERROR
+            : GENERIC_ERROR
+        );
+      }
+    } catch (error) {
+      setSubmissionError(GENERIC_ERROR);
+      //todo: https://docs.google.com/document/d/1RS1UnB0mB0aRISJQ50sOUNsElgAoAFGHbdJiBJf_I90/edit?tab=t.0 (in PR notes)
+    }
+  };
+
+  return <div>Five</div>;
+};
+
+export default CreateAccountStepFive;

--- a/frontend/src/components/createAccountSteps/CreateAccountStepFour.jsx
+++ b/frontend/src/components/createAccountSteps/CreateAccountStepFour.jsx
@@ -1,0 +1,5 @@
+const CreateAccountStepFour = () => {
+  return <div>Four</div>;
+};
+
+export default CreateAccountStepFour;

--- a/frontend/src/components/createAccountSteps/CreateAccountStepOne.jsx
+++ b/frontend/src/components/createAccountSteps/CreateAccountStepOne.jsx
@@ -6,8 +6,8 @@ import {
   UPPERCASE_LETTER,
   LOWERCASE_LETTER,
   NUMBER,
-} from "../utils/regex";
-import { EMAIL_ERROR } from "../utils/constants";
+} from "../../utils/regex";
+import { EMAIL_ERROR } from "../../utils/constants";
 
 const CreateAccountStepOne = (props) => {
   const [fullNameError, setFullNameError] = useState("");
@@ -50,7 +50,6 @@ const CreateAccountStepOne = (props) => {
     setFullNameError("");
     setEmailError("");
     setPasswordError("");
-    setSubmissionError("");
 
     if (props.fullName.trim().split(ONE_OR_MORE_WHITESPACE_REGEX).length < 2) {
       setFullNameError(FULL_NAME_ERROR);
@@ -65,7 +64,7 @@ const CreateAccountStepOne = (props) => {
 
     props.setFullName(props.fullName.trim());
     props.setEmail(props.email.trim());
-    props.setCurrentStep(props.currentStep++);
+    props.setCurrentStep(props.currentStep + 1);
   };
 
   return (

--- a/frontend/src/components/createAccountSteps/CreateAccountStepThree.jsx
+++ b/frontend/src/components/createAccountSteps/CreateAccountStepThree.jsx
@@ -1,0 +1,5 @@
+const CreateAccountStepThree = () => {
+  return <div>Three</div>;
+};
+
+export default CreateAccountStepThree;

--- a/frontend/src/components/createAccountSteps/CreateAccountStepTwo.jsx
+++ b/frontend/src/components/createAccountSteps/CreateAccountStepTwo.jsx
@@ -1,0 +1,5 @@
+const CreateAccountStepTwo = () => {
+  return <div>Two</div>;
+};
+
+export default CreateAccountStepTwo;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -21,6 +21,7 @@
   --background-light: #f0f7ff;
   --background-mixed: #d3e7fc;
   --background-darker: #c6e2ff;
+  --background-dark: #1083ff;
   --background-neutral-light: #e8e8e8;
 
   --main-color: #101010;
@@ -29,6 +30,7 @@
   --gray: #a9a8a8;
   --light-gray: #d9d9d9;
   --error-red: rgb(178, 47, 47);
+  --logout-error-red: rgb(255, 136, 136);
   --correct-green: rgb(42, 159, 42);
 }
 

--- a/frontend/src/utils/functions.js
+++ b/frontend/src/utils/functions.js
@@ -1,0 +1,23 @@
+import { Path } from "./enums";
+import { LOGGED_IN } from "./constants";
+
+export const checkUserLoggedIn = async () => {
+  try {
+    const response = await fetch(
+      `${import.meta.env.VITE_BASE_URL}${Path.CHECK_CREDENTIALS}`,
+      {
+        method: "GET",
+        credentials: "include",
+      }
+    );
+
+    if (response.ok) {
+      const data = await response.json();
+      return data?.message === LOGGED_IN;
+    } else {
+      return false;
+    }
+  } catch (error) {
+    return false;
+  }
+};


### PR DESCRIPTION
In this PR, I completed the following

Refactor Create Account Page

- Implement 5 components called within create account page dependent on current step (out of 5) user is on; load each component dynamically based on the current page
- Move current logic for full name/email/password into step 1 with props passed in to assign these values
- Refactor step 1 submission logic to defer submission to backend until step 5; instead move user to step 2

404 Error Page

- Redirect user to error component whenever invalid route is accessed
- Implement CSS animation to mimic swinging effect (symbolizing broken/invalid URL accessed)
- Detect if user is logged in or not, then offer redirect link to explore or login pages (depending on logged in status)
- Refactor check logged in function to call in various functions

Other

- Re-style log out error

<div>
    <a href="https://www.loom.com/share/b83c2511940347c29e60f52ccf278e7b">
      <p>Test Case Walkthrough</p>
    </a>
    <a href="https://www.loom.com/share/b83c2511940347c29e60f52ccf278e7b">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/b83c2511940347c29e60f52ccf278e7b-31be68b89fc6e06f-full-play.gif">
    </a>
  </div>