### PR TITLE
Implement email page structure, implement create email frontend fields & validation

### DIFF
--- a/backend/api/server.js
+++ b/backend/api/server.js
@@ -110,7 +110,7 @@ server.post(Path.CREATE_ACCOUNT, async (req, res, next) => {
   try {
     if (
       !fullNameValid(newUser?.fullName) ||
-      !emailValid(newUser?.email) ||
+      !emailValid(newUser?.email.trim()) ||
       !passwordValid(newUser?.password) ||
       !newUser?.pfpUrl ||
       !arrayValid(newUser?.interests, SKILLS_INTERESTS_MIN_LENGTH) ||
@@ -128,7 +128,7 @@ server.post(Path.CREATE_ACCOUNT, async (req, res, next) => {
     }
 
     const hash = await argon2.hash(newUser.password);
-    newUser = { ...newUser, password: hash };
+    newUser = { ...newUser, email: newUser?.email.trim(), password: hash };
 
     const created = await User.create(newUser);
     req.session.user = created;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -185,13 +185,13 @@ footer {
   border: none;
 }
 
-.create-account-back-icon {
+.create-account-back-icon, .email-remove {
   font-size: var(--subtitle-size);
   color: var(--main-color);
   cursor: pointer;
 }
 
-.create-account-back-icon:hover {
+.create-account-back-icon:hover, .email-remove:hover {
   color: var(--dark-gray);
 }
 
@@ -574,4 +574,40 @@ footer {
   width: 100vw;
   margin: 0 0 5vh -5vw;
   align-items: center;
+}
+
+.create-email-back-container {
+  align-self: flex-start;
+}
+
+.disable-add-email {
+  background-color: var(--background-light);
+  cursor:default;
+}
+
+.disable-add-email:hover {
+  background-color: var(--background-light);
+  border: 1px solid var(--gray);
+}
+
+.email-container {
+  display: flex;
+  gap: 50px;
+  align-items: center;
+  height: 35px;
+  padding: 10px 0 10px 0;
+}
+
+.email-list-btn {
+  height: 35px;
+  width: 80px;
+  font-size: var(--large-text-size)
+}
+
+.email-list-btn-selected {
+  background-color: var(--background-darker-2);
+}
+
+.email-remove {
+  font-size: var(--header-size)
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -611,3 +611,19 @@ footer {
 .email-remove {
   font-size: var(--header-size)
 }
+
+.dropdown-input-error {
+  position: relative;
+  margin-top: -26px;
+}
+
+.email-input {
+  background-color: transparent;
+}
+
+.create-email-submission-error {
+  font-size: var(--small-text-size);
+  color: var(--error-red);
+  font-weight: 600;
+  margin-top: 5px;
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -493,6 +493,7 @@ footer {
   flex-direction: column;
   align-items: center;
   overflow: scroll;
+  height: 100%;
 }
 
 .page-title {
@@ -537,4 +538,40 @@ footer {
 .email-topic-dropdown {
   margin-bottom: 0px;
   cursor: pointer;
+}
+
+.create-email-form {
+  align-self: flex-start;
+  display: flex;
+  flex-direction: column;
+  margin-left: 5vw;
+  gap: 30px;
+}
+
+.create-email-section-spacing {
+  margin-bottom: 50px;
+}
+
+.create-email-section-spacing-top {
+  margin-top: 50px;
+}
+
+.add-email-address-btn {
+  width: 250px;
+  font-size: var(--large-text-size);
+  margin: 0;
+}
+
+.create-email-body {
+  background-color: transparent;
+  width: 40vw;
+  max-width: 40vw;
+  min-width: 40vw;
+  min-height: 25px;
+}
+
+.create-email-btn {
+  width: 100vw;
+  margin: 0 0 5vh -5vw;
+  align-items: center;
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -259,7 +259,8 @@ footer {
   cursor: pointer;
 }
 
-.form-btn:hover {
+.form-btn:hover,
+.create-btn:hover {
   border-width: 2px;
   background-color: var(--background-darker);
 }
@@ -485,4 +486,55 @@ footer {
 
 .dropdown-item-x:hover {
   color: var(--dark-gray);
+}
+
+.page-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  overflow: scroll;
+}
+
+.page-title {
+  margin: 0;
+  padding: 3vh 0 3vh 0;
+  font-family: var(--header-font);
+  font-weight: normal;
+  font-size: var(--subtitle-size);
+}
+
+.page-big-header {
+  font-family: var(--subtitle-font);
+  font-size: var(--header-size);
+  font-weight: normal;
+}
+
+.create-btn {
+  align-self: flex-start;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  width: 200px;
+  height: 45px;
+  margin-left: 5vw;
+  border-radius: 20px;
+  font-size: var(--subheader-size);
+  font-family: var(--header-font);
+  background-color: var(--background-mixed);
+  border: 1px solid var(--gray);
+  cursor: pointer;
+}
+
+.email-sent-filter-container {
+  align-self: flex-start;
+  display: flex;
+  align-items: center;
+  margin: 30px 0 0 5vw;
+  gap: 100px;
+}
+
+.email-topic-dropdown {
+  margin-bottom: 0px;
+  cursor: pointer;
 }

--- a/frontend/src/components/CreateEmail.jsx
+++ b/frontend/src/components/CreateEmail.jsx
@@ -1,9 +1,111 @@
+import { useState } from "react";
+import { EMAIL_TOPICS, ALL_EMAIL_TOPICS } from "../utils/constants";
+
 const CreateEmail = () => {
+  const [emailTopic, setEmailTopic] = useState("");
+  const [subjectLine, setSubjectLine] = useState("");
+  const [emails, setEmails] = useState([]);
+  const [body, setBody] = useState("");
   const TITLE = "Create Email";
+  const EMAIL_TOPIC = "Email Topic";
+  const EMAIL_TOPIC_PLACEHOLDER = "Select an email topic";
+  const SUBJECT_LINE = "Subject Line";
+  const SUBJECT_LINE_PLACEHOLDER = "Enter email subject line";
+  const TO_CC = "To/CC";
+  const ADD_EMAIL_ADDRESS = "Add Email Address";
+  const TO = "To";
+  const CC = "CC";
+  const BODY = "Body";
+  const BODY_PLACEHOLDER = "Enter email body";
+
+  const addNewEmailAddress = () => {
+    setEmails([
+      ...emails,
+      {
+        emailAddress: "",
+        toOrCC: TO,
+      },
+    ]);
+  };
 
   return (
-    <div>
+    <div className="page-container">
       <h1 className="page-title">{TITLE}</h1>
+      <form className="create-email-form">
+        <label htmlFor="email-topic" className="page-big-header">
+          {EMAIL_TOPIC}
+        </label>
+        <select
+          id="email-topic"
+          value={emailTopic}
+          className="text-input email-topic-dropdown create-email-section-spacing"
+          onChange={(event) => setEmailTopic(event.target.value)}
+        >
+          <option value="" disabled>
+            {EMAIL_TOPIC_PLACEHOLDER}
+          </option>
+          {EMAIL_TOPICS.filter((topic) => topic !== ALL_EMAIL_TOPICS).map(
+            (topic, index) => (
+              <option key={index} value={topic}>
+                {topic}
+              </option>
+            )
+          )}
+        </select>
+
+        <label htmlFor="subject-line" className="page-big-header">
+          {SUBJECT_LINE}
+        </label>
+        <div className="text-input-container">
+          <input
+            id="subject-line"
+            type="text"
+            className="text-input create-email-section-spacing"
+            placeholder={SUBJECT_LINE_PLACEHOLDER}
+            value={subjectLine}
+            maxLength={125}
+            onChange={(event) => setSubjectLine(event.target.value)}
+          />
+        </div>
+
+        <label className="page-big-header">{TO_CC}</label>
+        <div
+          className="create-btn add-email-address-btn"
+          onClick={addNewEmailAddress}
+        >
+          <span className="material-symbols-outlined">add_2</span>
+          {ADD_EMAIL_ADDRESS}
+        </div>
+        {emails.map((email, index) => (
+          <div key={index}>
+            <span>
+              {email.emailAddress}, {email.toOrCC}
+            </span>
+          </div>
+        ))}
+
+        <label
+          htmlFor="body"
+          className="page-big-header create-email-section-spacing-top"
+        >
+          {BODY}
+        </label>
+        <div className="text-input-container">
+          <textarea
+            id="body"
+            className="text-input create-email-section-spacing create-email-body"
+            placeholder={BODY_PLACEHOLDER}
+            value={body}
+            onChange={(event) => setBody(event.target.value)}
+          />
+        </div>
+
+        <div className="text-input-container create-email-btn">
+          <button type="submit" className="form-btn">
+            Continue
+          </button>
+        </div>
+      </form>
     </div>
   );
 };

--- a/frontend/src/components/CreateEmail.jsx
+++ b/frontend/src/components/CreateEmail.jsx
@@ -1,7 +1,11 @@
 import { useState } from "react";
+import { Path } from "../utils/enums";
 import { EMAIL_TOPICS, ALL_EMAIL_TOPICS } from "../utils/constants";
+import {useNavigate} from "react-router-dom";
+import CreateEmailList from "./createEmailList/CreateEmailList";
 
 const CreateEmail = () => {
+  const navigate = useNavigate();
   const [emailTopic, setEmailTopic] = useState("");
   const [subjectLine, setSubjectLine] = useState("");
   const [emails, setEmails] = useState([]);
@@ -14,7 +18,6 @@ const CreateEmail = () => {
   const TO_CC = "To/CC";
   const ADD_EMAIL_ADDRESS = "Add Email Address";
   const TO = "To";
-  const CC = "CC";
   const BODY = "Body";
   const BODY_PLACEHOLDER = "Enter email body";
 
@@ -30,6 +33,14 @@ const CreateEmail = () => {
 
   return (
     <div className="page-container">
+      <button
+        className="create-account-back-container create-email-back-container"
+        onClick={() => navigate(Path.EMAIL)}
+      >
+        <span className="material-symbols-outlined create-account-back-icon">
+          west
+        </span>
+      </button>
       <h1 className="page-title">{TITLE}</h1>
       <form className="create-email-form">
         <label htmlFor="email-topic" className="page-big-header">
@@ -70,19 +81,13 @@ const CreateEmail = () => {
 
         <label className="page-big-header">{TO_CC}</label>
         <div
-          className="create-btn add-email-address-btn"
-          onClick={addNewEmailAddress}
+          className={`create-btn add-email-address-btn ${emails.length < 20 ? "" : "disable-add-email"}`}
+          onClick={() => emails.length < 20 ? addNewEmailAddress() : null}
         >
           <span className="material-symbols-outlined">add_2</span>
           {ADD_EMAIL_ADDRESS}
         </div>
-        {emails.map((email, index) => (
-          <div key={index}>
-            <span>
-              {email.emailAddress}, {email.toOrCC}
-            </span>
-          </div>
-        ))}
+        <CreateEmailList emails={emails} setEmails={setEmails}/>
 
         <label
           htmlFor="body"

--- a/frontend/src/components/CreateEmail.jsx
+++ b/frontend/src/components/CreateEmail.jsx
@@ -1,5 +1,11 @@
 const CreateEmail = () => {
-  return <div>Create Email</div>;
+  const TITLE = "Create Email";
+
+  return (
+    <div>
+      <h1 className="page-title">{TITLE}</h1>
+    </div>
+  );
 };
 
 export default CreateEmail;

--- a/frontend/src/components/CreateEmail.jsx
+++ b/frontend/src/components/CreateEmail.jsx
@@ -1,15 +1,26 @@
 import { useState } from "react";
 import { Path } from "../utils/enums";
-import { EMAIL_TOPICS, ALL_EMAIL_TOPICS } from "../utils/constants";
-import {useNavigate} from "react-router-dom";
+import {
+  EMAIL_TOPICS,
+  ALL_EMAIL_TOPICS,
+  GENERIC_ERROR,
+} from "../utils/constants";
+import { EMAIL_REGEX } from "../utils/regex";
+import { useNavigate } from "react-router-dom";
 import CreateEmailList from "./createEmailList/CreateEmailList";
 
 const CreateEmail = () => {
   const navigate = useNavigate();
   const [emailTopic, setEmailTopic] = useState("");
+  const [emailTopicError, setEmailTopicError] = useState("");
   const [subjectLine, setSubjectLine] = useState("");
+  const [subjectLineError, setSubjectLineError] = useState("");
   const [emails, setEmails] = useState([]);
+  // According to Outlook & Gmail, can send an email with at least 1 "To" recipient or 1 "CC" recipient
+  const [emailsError, setEmailsError] = useState("");
   const [body, setBody] = useState("");
+  const [bodyError, setBodyError] = useState("");
+  const [submissionError, setSubmissionError] = useState("");
   const TITLE = "Create Email";
   const EMAIL_TOPIC = "Email Topic";
   const EMAIL_TOPIC_PLACEHOLDER = "Select an email topic";
@@ -20,6 +31,13 @@ const CreateEmail = () => {
   const TO = "To";
   const BODY = "Body";
   const BODY_PLACEHOLDER = "Enter email body";
+  const SEND_EMAIL = "Send Email";
+  const EMAIL_TOPIC_ERROR_MESSAGE = "Please select an email topic";
+  const SUBJECT_LINE_ERROR_MESSAGE = "Please provide a subject line";
+  const NO_EMAILS_ERROR_MESSAGE = "Please provide at least one email address";
+  const INVALID_EMAIL_ERROR_MESSAGE = "At least one email provided is invalid";
+  const DUPLICATE_EMAILS_ERROR_MESSAGE = "Duplicate emails have been provided";
+  const BODY_ERROR_MESSAGE = "Please provide a body";
 
   const addNewEmailAddress = () => {
     setEmails([
@@ -29,6 +47,47 @@ const CreateEmail = () => {
         toOrCC: TO,
       },
     ]);
+  };
+
+  const submitEmail = async (event) => {
+    event.preventDefault();
+    setEmailTopicError("");
+    setSubjectLineError("");
+    setEmailsError("");
+    setBodyError("");
+
+    const newEmails = emails.map((email) => {
+      return { ...email, emailAddress: email.emailAddress.trim() };
+    });
+    const newSubjectLine = subjectLine.trim();
+    const newBody = body.trim();
+
+    const emailAddresses = newEmails.map((email) => email.emailAddress);
+    const duplicateAddresses = emailAddresses.filter(
+      (emailAddress, index) => emailAddresses.indexOf(emailAddress) !== index
+    );
+
+    if (!emailTopic) {
+      setEmailTopicError(EMAIL_TOPIC_ERROR_MESSAGE);
+      return;
+    } else if (!newSubjectLine) {
+      setSubjectLineError(SUBJECT_LINE_ERROR_MESSAGE);
+      return;
+    } else if (newEmails.length === 0) {
+      setEmailsError(NO_EMAILS_ERROR_MESSAGE);
+      return;
+    } else if (
+      newEmails.some((email) => !EMAIL_REGEX.test(email.emailAddress))
+    ) {
+      setEmailsError(INVALID_EMAIL_ERROR_MESSAGE);
+      return;
+    } else if (duplicateAddresses.length > 0) {
+      setEmailsError(DUPLICATE_EMAILS_ERROR_MESSAGE);
+      return;
+    } else if (!newBody) {
+      setBodyError(BODY_ERROR_MESSAGE);
+      return;
+    }
   };
 
   return (
@@ -42,14 +101,17 @@ const CreateEmail = () => {
         </span>
       </button>
       <h1 className="page-title">{TITLE}</h1>
-      <form className="create-email-form">
+      <form
+        className="create-email-form"
+        onSubmit={(event) => submitEmail(event)}
+      >
         <label htmlFor="email-topic" className="page-big-header">
           {EMAIL_TOPIC}
         </label>
         <select
           id="email-topic"
           value={emailTopic}
-          className="text-input email-topic-dropdown create-email-section-spacing"
+          className="text-input email-topic-dropdown"
           onChange={(event) => setEmailTopic(event.target.value)}
         >
           <option value="" disabled>
@@ -63,6 +125,9 @@ const CreateEmail = () => {
             )
           )}
         </select>
+        <div className="create-email-section-spacing text-input-error dropdown-input-error">
+          {emailTopicError}
+        </div>
 
         <label htmlFor="subject-line" className="page-big-header">
           {SUBJECT_LINE}
@@ -71,44 +136,55 @@ const CreateEmail = () => {
           <input
             id="subject-line"
             type="text"
-            className="text-input create-email-section-spacing"
+            className="text-input"
             placeholder={SUBJECT_LINE_PLACEHOLDER}
             value={subjectLine}
             maxLength={125}
             onChange={(event) => setSubjectLine(event.target.value)}
           />
+          <div className="create-email-section-spacing text-input-error dropdown-input-error">
+            {subjectLineError}
+          </div>
         </div>
 
         <label className="page-big-header">{TO_CC}</label>
         <div
-          className={`create-btn add-email-address-btn ${emails.length < 20 ? "" : "disable-add-email"}`}
-          onClick={() => emails.length < 20 ? addNewEmailAddress() : null}
+          className={`create-btn add-email-address-btn ${
+            emails.length < 20 ? "" : "disable-add-email"
+          }`}
+          onClick={() => (emails.length < 20 ? addNewEmailAddress() : null)}
         >
           <span className="material-symbols-outlined">add_2</span>
           {ADD_EMAIL_ADDRESS}
         </div>
-        <CreateEmailList emails={emails} setEmails={setEmails}/>
+        <CreateEmailList emails={emails} setEmails={setEmails} />
+        <div className="create-email-section-spacing text-input-error dropdown-input-error">
+          {emailsError}
+        </div>
 
-        <label
-          htmlFor="body"
-          className="page-big-header create-email-section-spacing-top"
-        >
+        <label htmlFor="body" className="page-big-header">
           {BODY}
         </label>
         <div className="text-input-container">
           <textarea
             id="body"
-            className="text-input create-email-section-spacing create-email-body"
+            className="text-input create-email-body"
             placeholder={BODY_PLACEHOLDER}
             value={body}
             onChange={(event) => setBody(event.target.value)}
           />
+          <div className="create-email-section-spacing text-input-error dropdown-input-error">
+            {bodyError}
+          </div>
         </div>
 
         <div className="text-input-container create-email-btn">
           <button type="submit" className="form-btn">
-            Continue
+            {SEND_EMAIL}
           </button>
+          <span className="create-email-submission-error">
+            {submissionError}
+          </span>
         </div>
       </form>
     </div>

--- a/frontend/src/components/Email.jsx
+++ b/frontend/src/components/Email.jsx
@@ -1,5 +1,35 @@
-const Email = () => {
-  return <div>Email</div>;
-};
+import { useState } from "react";
+import { EMAIL_TOPICS } from "../utils/constants";
 
+const Email = () => {
+  const [selectedTopic, setSelectedTopic] = useState("All Email Topics");
+  const TITLE = "Email";
+  const BUTTON_TEXT = "Create Email";
+  const SENT_EMAILS = "Sent Emails";
+  const EMAIL_TOPIC = "Email Topic";
+
+  return (
+    <div className="page-container">
+      <h1 className="page-title">{TITLE}</h1>
+      <button className="create-btn">
+        <span className="material-symbols-outlined">add_2</span>
+        {BUTTON_TEXT}
+      </button>
+      <div className="email-sent-filter-container">
+        <h2 className="page-big-header">{SENT_EMAILS}</h2>
+        <select
+          value={selectedTopic}
+          className="text-input email-topic-dropdown"
+          onChange={(event) => setSelectedTopic(event.target.value)}
+        >
+          {EMAIL_TOPICS.map((topic, index) => (
+            <option key={index} value={topic}>
+              {topic}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+};
 export default Email;

--- a/frontend/src/components/Email.jsx
+++ b/frontend/src/components/Email.jsx
@@ -1,17 +1,22 @@
 import { useState } from "react";
-import { EMAIL_TOPICS } from "../utils/constants";
+import { EMAIL_TOPICS, ALL_EMAIL_TOPICS } from "../utils/constants";
+import { useNavigate } from "react-router-dom";
+import { Path } from "../utils/enums";
 
 const Email = () => {
-  const [selectedTopic, setSelectedTopic] = useState("All Email Topics");
+  const navigate = useNavigate();
+  const [selectedTopic, setSelectedTopic] = useState(ALL_EMAIL_TOPICS);
   const TITLE = "Email";
   const BUTTON_TEXT = "Create Email";
   const SENT_EMAILS = "Sent Emails";
-  const EMAIL_TOPIC = "Email Topic";
 
   return (
     <div className="page-container">
       <h1 className="page-title">{TITLE}</h1>
-      <button className="create-btn">
+      <button
+        className="create-btn"
+        onClick={() => navigate(Path.CREATE_EMAIL)}
+      >
         <span className="material-symbols-outlined">add_2</span>
         {BUTTON_TEXT}
       </button>

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -25,15 +25,15 @@ const Login = () => {
     setPasswordError("");
     setSubmissionError("");
 
-    if (!EMAIL_REGEX.test(email)) {
+    const userEmail = email.trim();
+
+    if (!EMAIL_REGEX.test(userEmail)) {
       setEmailError(EMAIL_ERROR);
       return;
     } else if (!password) {
       setPasswordError(PASSWORD_EMPTY_ERROR);
       return;
     }
-
-    const userEmail = email.trim();
 
     try {
       const userCredentials = {

--- a/frontend/src/components/createAccountSteps/CreateAccountStepOne.jsx
+++ b/frontend/src/components/createAccountSteps/CreateAccountStepOne.jsx
@@ -58,7 +58,7 @@ const CreateAccountStepOne = (props) => {
     if (props.fullName.trim().split(ONE_OR_MORE_WHITESPACE_REGEX).length < 2) {
       setFullNameError(FULL_NAME_ERROR);
       return;
-    } else if (!EMAIL_REGEX.test(props.email)) {
+    } else if (!EMAIL_REGEX.test(props.email.trim())) {
       setEmailError(EMAIL_ERROR);
       return;
     } else if (Object.values(passwordRequirementsMet).includes(false)) {

--- a/frontend/src/components/createEmailList/CreateEmailList.jsx
+++ b/frontend/src/components/createEmailList/CreateEmailList.jsx
@@ -31,7 +31,7 @@ const CreateEmailList = (props) => {
           <div className="text-input-container">
             <input
               type="text"
-              className="text-input"
+              className="text-input email-input"
               placeholder={EMAIL_ADDRESS_PLACEHOLDER}
               value={email.emailAddress}
               maxLength={125}

--- a/frontend/src/components/createEmailList/CreateEmailList.jsx
+++ b/frontend/src/components/createEmailList/CreateEmailList.jsx
@@ -1,0 +1,77 @@
+const CreateEmailList = (props) => {
+  const EMAIL_ADDRESS_PLACEHOLDER = "Enter email address";
+  const TO = "To";
+  const CC = "CC";
+
+  const updateEmailAddress = (newEmailAddress, index) => {
+    const newEmails = props.emails.map((email, idx) => {
+      if (idx === index) {
+        return { ...email, emailAddress: newEmailAddress };
+      }
+      return email;
+    });
+    props.setEmails(newEmails);
+  };
+
+  const changeToOrCC = (event, toOrCC, index) => {
+    event.preventDefault();
+    const newEmails = props.emails.map((email, idx) => {
+      if (idx === index) {
+        return { ...email, toOrCC: toOrCC };
+      }
+      return email;
+    });
+    props.setEmails(newEmails);
+  };
+
+  return (
+    <>
+      {props.emails.map((email, index) => (
+        <div key={index} className="email-container">
+          <div className="text-input-container">
+            <input
+              type="text"
+              className="text-input"
+              placeholder={EMAIL_ADDRESS_PLACEHOLDER}
+              value={email.emailAddress}
+              maxLength={125}
+              onChange={(event) =>
+                updateEmailAddress(event.target.value, index)
+              }
+            />
+          </div>
+          <button
+            onClick={(event) => changeToOrCC(event, TO, index)}
+            className={`form-btn email-list-btn ${
+              email.toOrCC === TO ? "email-list-btn-selected" : ""
+            }`}
+          >
+            {TO}
+          </button>
+          <button
+            onClick={(event) => changeToOrCC(event, CC, index)}
+            className={`form-btn email-list-btn ${
+              email.toOrCC === CC ? "email-list-btn-selected" : ""
+            }`}
+          >
+            {CC}
+          </button>
+          <div>
+            <span
+              onClick={() =>
+                props.setEmails(
+                  props.emails.filter((email, idx) => idx !== index)
+                )
+              }
+              className="material-symbols-outlined email-remove"
+            >
+              close
+            </span>
+          </div>
+        </div>
+      ))}
+    </>
+  );
+};
+
+export default CreateEmailList;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -21,6 +21,7 @@
   --background-light: #f0f7ff;
   --background-mixed: #d3e7fc;
   --background-darker: #c6e2ff;
+  --background-darker-2: #9ac9fc;
   --background-dark: #1083ff;
   --background-neutral-light: #e8e8e8;
 

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -6,8 +6,9 @@ export const DUPLICATE_EMAIL_ERROR = "Email is already in use";
 export const INVALID_LOGIN_ERROR = "Invalid login details. Please try again";
 export const EMAIL_ERROR = "Please enter a valid email address";
 export const LOGGED_IN = "Logged In";
+export const ALL_EMAIL_TOPICS = "All Email Topics";
 export const EMAIL_TOPICS = [
-  "All Email Topics",
+  ALL_EMAIL_TOPICS,
   "Course Selection Advice",
   "Course Availability",
   "Course Information",

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -6,6 +6,25 @@ export const DUPLICATE_EMAIL_ERROR = "Email is already in use";
 export const INVALID_LOGIN_ERROR = "Invalid login details. Please try again";
 export const EMAIL_ERROR = "Please enter a valid email address";
 export const LOGGED_IN = "Logged In";
+export const EMAIL_TOPICS = [
+  "All Email Topics",
+  "Course Selection Advice",
+  "Course Availability",
+  "Course Information",
+  "Course Registration Inquiry",
+  "Course Requirements",
+  "Degree Requirements",
+  "Designation Inquiry",
+  "Minors/Certificates Inquiry",
+  "Electives Inquiry",
+  "Humanities Inquiry",
+  "Timetable Conflicts",
+  "Timetable Inquiry",
+  "Waitlist Inquiry",
+  "Course Drop Inquiry",
+  "Other",
+];
+
 export const ECE_AREAS = {
   PHOTONICS_SEMICONDUCTOR: "Photonics & Semiconductor Physics",
   ENERGY_ELECTROMAGNETICS: "Electromagnetics & Energy Systems",


### PR DESCRIPTION
In this PR, I completed the following:

Email page

- Display title, sent emails section (to hold email data after it is added), and create email button redirecting to create email page

Create Email Page

- Implement fields for email topic, subject line, to/CC emails, and body
- Enable users to add up to 20 emails with choice between to or CC & delete email
- Implement frontend validation to check for an email topic, non-empty subject line & body, and check for at least 1 valid email with no duplicates
- Display error message for any validation or submission errors
- Implement back button functionality to return to email page


Other

- Refactored all uses of email regex to ensure it considers the email after applying .trim() (as per discussion with Lokesh)


<div>
    <a href="https://www.loom.com/share/b2a81fee628649449552745010243b53">
      <p>Test Case Walkthrough - Create Email & Email Frontend</p>
    </a>
    <a href="https://www.loom.com/share/b2a81fee628649449552745010243b53">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/b2a81fee628649449552745010243b53-f2bb1235aa07eccc-full-play.gif">
    </a>
  </div>