### PR TITLE
Implement loading & error message when generating timetable, implement partial timetable generation logic

### DIFF
--- a/backend/api/course-model.js
+++ b/backend/api/course-model.js
@@ -10,24 +10,28 @@ const getAllCourses = async () => {
           select: {
             code: true,
             title: true,
+            id: true
           },
         },
         corequisites: {
           select: {
             code: true,
             title: true,
+            id: true
           },
         },
         exclusions: {
           select: {
             code: true,
             title: true,
+            id: true
           },
         },
         recommendedPrep: {
           select: {
             code: true,
             title: true,
+            id: true
           },
         },
         inUserShoppingCart: true,

--- a/backend/api/server.js
+++ b/backend/api/server.js
@@ -581,9 +581,14 @@ server.get(`${Path.EXPLORE}${RECOMMENDATIONS_PATH}`, async (req, res, next) => {
 });
 
 server.post(`${Path.TIMETABLE}${GENERATE_PATH}`, async (req, res, next) => {
+  const timetableId = req.query?.id;
+
   try {
+    if (!timetableId || !ONLY_NUMBERS.test(timetableId))
+      throw new Error(INVALID_TIMETABLE_ID);
+
     const userId = Number(req.session?.user?.id);
-    await generateTimetable(userId);
+    await generateTimetable(userId, Number(timetableId));
     res.status(201).end();
   } catch (err) {
     next(err);

--- a/backend/api/server.js
+++ b/backend/api/server.js
@@ -26,6 +26,7 @@ const {
   CONFLICT_STATUS_PATH,
   RECOMMENDATIONS_PATH,
   REJECT_PATH,
+  GENERATE_PATH,
 } = require("../../frontend/src/utils/constants");
 const { Path } = require("../../frontend/src/utils/enums");
 
@@ -44,6 +45,7 @@ const sendGrid = require("@sendgrid/mail");
 sendGrid.setApiKey(process.env.SENDGRID_API_KEY);
 //todo: https://docs.google.com/document/d/1RS1UnB0mB0aRISJQ50sOUNsElgAoAFGHbdJiBJf_I90/edit?usp=sharing
 const { findRecommendedCourses } = require("../utils/findRecommendedCourses");
+const { generateTimetable } = require("../utils/generateTimetable");
 
 const INVALID_USER_DETAILS_ERROR = "Invalid details provided";
 const INVALID_EMAIL_DETAILS_ERROR = "Invalid email details provided";
@@ -573,6 +575,16 @@ server.get(`${Path.EXPLORE}${RECOMMENDATIONS_PATH}`, async (req, res, next) => {
     const courses = await Course.findCourses(userId);
     const recommendedCourses = await findRecommendedCourses(courses, userId, true);
     res.status(200).json({ recommendedCourses });
+  } catch (err) {
+    next(err);
+  }
+});
+
+server.post(`${Path.TIMETABLE}${GENERATE_PATH}`, async (req, res, next) => {
+  try {
+    const userId = Number(req.session?.user?.id);
+    await generateTimetable(userId);
+    res.status(201).end();
   } catch (err) {
     next(err);
   }

--- a/backend/utils/generateTimetable.js
+++ b/backend/utils/generateTimetable.js
@@ -1,11 +1,20 @@
 import Course from "../api/course-model.js";
+import User from "../api/user-model.js";
 import { createIdListFromObjectList } from "./findRecommendedCourses.js";
+import {
+  initializeAreaCoursesList,
+  updateAreaCoursesList,
+} from "../../frontend/src/utils/requirementsCheck.js";
 
 const MINIMUM_COURSES = 20;
+const MINIMUM_KERNEL_COURSES = 1;
+const MINIMUM_DEPTH_COURSES = 2;
 const NOT_ENOUGH_COURSES_ERROR =
   "A minimum of 20 courses are required in the shopping cart to generate a timetable";
 const NOT_ENOUGH_COURSES_AFTER_REFINING_ERROR =
   "A minimum of 20 courses are required in the shopping cart, with all course requirements met by other shopping cart courses, to generate a timetable";
+const MINIMUM_KERNEL_DEPTH_COURSES_ERROR =
+  "A minimum of 1 unique course is needed per non-depth kernel area & 2 unique courses per depth/kernel area";
 
 const isPrereqOrCoreqMet = (
   prereqOrCoreqList,
@@ -41,7 +50,42 @@ const areMinimumRequirementsMet = (course, shoppingCartIdList) => {
   return true;
 };
 
-export const generateTimetable = async (userId) => {
+const checkIfOtherAreaNeedsCourse = (
+  courseId,
+  area,
+  areaCourseLists,
+  timetableDepth
+) => {
+  const matchingAreaCourseList = areaCourseLists.find(
+    (areaCourseList) => areaCourseList.area === area
+  );
+  const minimumCoursesForOtherArea = timetableDepth.includes(
+    matchingAreaCourseList?.area
+  )
+    ? MINIMUM_DEPTH_COURSES
+    : MINIMUM_KERNEL_COURSES;
+
+  if (
+    matchingAreaCourseList &&
+    matchingAreaCourseList.courses.some((course) => course.id === courseId) &&
+    matchingAreaCourseList.courses.length === minimumCoursesForOtherArea
+  )
+    return true;
+
+  return false;
+};
+
+const numberOfKernelAreaMatches = (areaList, kernelList) => {
+  let matchCount = 0;
+
+  areaList.forEach((area) => {
+    if (kernelList.includes(area)) matchCount++;
+  });
+
+  return matchCount;
+};
+
+export const generateTimetable = async (userId, timetableId) => {
   const shoppingCartCourses = await Course.findCoursesInCart(userId);
   if (shoppingCartCourses.length < MINIMUM_COURSES)
     throw new Error(NOT_ENOUGH_COURSES_ERROR);
@@ -52,7 +96,54 @@ export const generateTimetable = async (userId) => {
   const refinedShoppingCart = shoppingCartCourses.filter((cartCourse) =>
     areMinimumRequirementsMet(cartCourse, shoppingCartIdList)
   );
-
   if (refinedShoppingCart.length < MINIMUM_COURSES)
     throw new Error(NOT_ENOUGH_COURSES_AFTER_REFINING_ERROR);
+
+  const timetable = await User.findUserTimetableByIds(timetableId, userId);
+  let areaCourseLists = [];
+  initializeAreaCoursesList(areaCourseLists, timetable.kernel);
+  refinedShoppingCart.forEach((course) => {
+    updateAreaCoursesList({ course }, areaCourseLists);
+  });
+
+  let usedCourseIds = structuredClone(areaCourseLists);
+  usedCourseIds.forEach((areaObject) => {
+    areaObject.courses = new Set([]);
+  });
+
+  areaCourseLists.forEach((areaCourseList) => {
+    let sortedCourseList = areaCourseList.courses.toSorted(
+      (crsA, crsB) =>
+        numberOfKernelAreaMatches(crsA.area, timetable.kernel) -
+        numberOfKernelAreaMatches(crsB.area.length, timetable.kernel)
+    );
+    let courseCount = 0;
+    let minimumCoursesNeeded = timetable.depth.includes(areaCourseList.area)
+      ? MINIMUM_DEPTH_COURSES
+      : MINIMUM_KERNEL_COURSES;
+
+    for (const course in sortedCourseList) {
+      if (
+        numberOfKernelAreaMatches(course.area) === 1 ||
+        (!course.area.some((area) =>
+          checkIfOtherAreaNeedsCourse(
+            course.id,
+            area,
+            areaCourseLists,
+            timetable.depth
+          )
+        ) &&
+          !usedCourseIds.has(course.id))
+      ) {
+        courseCount++;
+        usedCourseIds
+          .find((areaObject) => areaObject.area === areaCourseList.area)
+          ?.courses?.add(course.id);
+        if (courseCount === minimumCoursesNeeded) break;
+      }
+    }
+
+    if (areaCourseList.courses.length < minimumCoursesNeeded)
+      throw new Error(MINIMUM_KERNEL_DEPTH_COURSES_ERROR);
+  });
 };

--- a/backend/utils/generateTimetable.js
+++ b/backend/utils/generateTimetable.js
@@ -1,0 +1,58 @@
+import Course from "../api/course-model.js";
+import { createIdListFromObjectList } from "./findRecommendedCourses.js";
+
+const MINIMUM_COURSES = 20;
+const NOT_ENOUGH_COURSES_ERROR =
+  "A minimum of 20 courses are required in the shopping cart to generate a timetable";
+const NOT_ENOUGH_COURSES_AFTER_REFINING_ERROR =
+  "A minimum of 20 courses are required in the shopping cart, with all course requirements met by other shopping cart courses, to generate a timetable";
+
+const isPrereqOrCoreqMet = (
+  prereqOrCoreqList,
+  prereqOrCoreqAmount,
+  shoppingCartIdList
+) => {
+  if (prereqOrCoreqAmount === 0) return true;
+  let requirementsMet = 0;
+  prereqOrCoreqList.forEach((requirementCourse) => {
+    if (shoppingCartIdList.has(requirementCourse.id)) {
+      requirementsMet++;
+      if (requirementsMet === prereqOrCoreqAmount) return true;
+    }
+  });
+  return false;
+};
+
+const areMinimumRequirementsMet = (course, shoppingCartIdList) => {
+  if (
+    !isPrereqOrCoreqMet(
+      course.prerequisites,
+      course.prerequisiteAmount,
+      shoppingCartIdList
+    ) ||
+    !isPrereqOrCoreqMet(
+      course.corequisites,
+      course.corequisiteAmount,
+      shoppingCartIdList
+    )
+  )
+    return false;
+
+  return true;
+};
+
+export const generateTimetable = async (userId) => {
+  const shoppingCartCourses = await Course.findCoursesInCart(userId);
+  if (shoppingCartCourses.length < MINIMUM_COURSES)
+    throw new Error(NOT_ENOUGH_COURSES_ERROR);
+
+  const shoppingCartIdList = new Set(
+    createIdListFromObjectList(shoppingCartCourses)
+  );
+  const refinedShoppingCart = shoppingCartCourses.filter((cartCourse) =>
+    areMinimumRequirementsMet(cartCourse, shoppingCartIdList)
+  );
+
+  if (refinedShoppingCart.length < MINIMUM_COURSES)
+    throw new Error(NOT_ENOUGH_COURSES_AFTER_REFINING_ERROR);
+};

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1172,6 +1172,9 @@ footer {
   align-items: flex-start;
   justify-content: flex-start;
   gap: 70px;
+  height: 1720px;
+  padding-bottom: 50px;
+  overflow: scroll;
 }
 
 .timetable-cart-error {
@@ -1399,4 +1402,58 @@ footer {
   position: absolute;
   z-index: 2;
   font-weight: 500;
+}
+
+.error-modal-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.386);
+  z-index: 2;
+  display:flex;
+}
+
+.error-modal {
+  width: 40vw;
+  height: 50vh;
+  background-color: var(--background-darker);
+  position: absolute;
+  align-self: center;
+  left: 30vw;
+  border-radius: 30px;
+  box-shadow: 10px 10px 30px black;
+  border: 2px solid var(--light-gray);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.timetable-generate-error-title {
+  font-family: var(--header-font);
+  font-weight: normal;
+  padding-bottom: 8%;
+  margin: 0 15px 0 15px;
+}
+
+.timetable-generate-error-message {
+  font-family: var(--header-font);
+  font-size: var(--subheader-size);
+  font-weight: normal;
+  margin: 0 35px 0 35px;
+  text-align: center;
+}
+
+.close-modal {
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  font-size: var(--subtitle-size);
+  cursor: pointer;
+}
+
+.close-modal:hover {
+  color: var(--dark-gray)
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1348,6 +1348,14 @@ footer {
   animation: spin 2s ease-in-out infinite;
 }
 
+.timetable-loader {
+  width: 10vw;
+  height: 10vw;
+  align-self: center;
+  left: 45vw;
+  position: relative;
+}
+
 @keyframes spin {
   0% {
     transform: rotate(0deg);

--- a/frontend/src/components/Timetable.jsx
+++ b/frontend/src/components/Timetable.jsx
@@ -19,6 +19,7 @@ import {
   DESIGNATION_PATH,
   initialErrors,
   CONFLICT_STATUS_PATH,
+  GENERATE_PATH,
 } from "../utils/constants";
 import { fetchCoursesInCart } from "../utils/fetchShoppingCart";
 import ExploreCourse from "./exploreCourseList/ExploreCourse";
@@ -55,6 +56,7 @@ const Timetable = () => {
   const [fetchCartCoursesError, setFetchCartCoursesError] = useState("");
   const [selectedCourse, setSelectedCourse] = useState(null);
   const [updateTimetableError, setUpdateTimetableError] = useState("");
+  const [generateTimetableError, setGenerateTimetableError] = useState("");
   const [isRequirementsMenuOpen, setIsRequirementsMenuOpen] = useState(false);
   const [terms, setTerms] = useState(initialTerms);
   const [errors, setErrors] = useState(initialErrors);
@@ -84,6 +86,7 @@ const Timetable = () => {
   const OTHER_COURSES = "11 Other Courses: ";
   const NO_COURSE = "No course added yet";
   const NO_ERRORS = "Great job - no errors found!";
+  const TIMETABLE_ERROR_TITLE = "Unable to Generate Timetable";
 
   const filteredCoursesInCart = coursesInCart.filter(
     (course) =>
@@ -395,6 +398,29 @@ const Timetable = () => {
     );
   };
 
+  const generateTimetable = async () => {
+    try {
+      const response = await fetch(
+        `${import.meta.env.VITE_BASE_URL}${Path.TIMETABLE}${GENERATE_PATH}`,
+        {
+          method: "POST",
+          credentials: "include",
+        }
+      );
+
+      if (response.ok) {
+        fetchTimetableData(timetable?.id);
+      } else {
+        const error = await response.json();
+        setGenerateTimetableError(
+          error?.message ? error.message : GENERIC_ERROR
+        );
+      }
+    } catch (error) {
+      setGenerateTimetableError(error?.message ? error.message : GENERIC_ERROR);
+    }
+  };
+
   useEffect(() => {
     const callFetchTimetableData = async (id) => {
       await fetchTimetableData(id);
@@ -579,6 +605,7 @@ const Timetable = () => {
               <button
                 className="create-btn generate-background"
                 style={{ width: "250px" }}
+                onClick={generateTimetable}
               >
                 <span className="material-symbols-outlined">wand_stars</span>
                 {BUTTON_TEXT}
@@ -625,6 +652,26 @@ const Timetable = () => {
               </div>
             </section>
           ))}
+        </div>
+      </div>
+
+      <div
+        className="error-modal-container"
+        onClick={(event) =>
+          event.target.className === "error-modal"
+            ? null
+            : setGenerateTimetableError("")
+        }
+        style={generateTimetableError ? {} : { display: "none" }}
+      >
+        <div className="error-modal">
+          <span className="material-symbols-outlined close-modal">close</span>
+          <h2 className="timetable-generate-error-title">
+            {TIMETABLE_ERROR_TITLE}
+          </h2>
+          <h3 className="timetable-generate-error-message">
+            {generateTimetableError}
+          </h3>
         </div>
       </div>
 

--- a/frontend/src/components/Timetable.jsx
+++ b/frontend/src/components/Timetable.jsx
@@ -57,6 +57,7 @@ const Timetable = () => {
   const [selectedCourse, setSelectedCourse] = useState(null);
   const [updateTimetableError, setUpdateTimetableError] = useState("");
   const [generateTimetableError, setGenerateTimetableError] = useState("");
+  const [isTimetableGenerating, setIsTimetableGenerating] = useState(false);
   const [isRequirementsMenuOpen, setIsRequirementsMenuOpen] = useState(false);
   const [terms, setTerms] = useState(initialTerms);
   const [errors, setErrors] = useState(initialErrors);
@@ -400,6 +401,7 @@ const Timetable = () => {
 
   const generateTimetable = async () => {
     try {
+      setIsTimetableGenerating(true);
       const response = await fetch(
         `${import.meta.env.VITE_BASE_URL}${
           Path.TIMETABLE
@@ -409,6 +411,7 @@ const Timetable = () => {
           credentials: "include",
         }
       );
+      setIsTimetableGenerating(false);
 
       if (response.ok) {
         fetchTimetableData(timetable?.id);
@@ -419,6 +422,7 @@ const Timetable = () => {
         );
       }
     } catch (error) {
+      setIsTimetableGenerating(false);
       setGenerateTimetableError(error?.message ? error.message : GENERIC_ERROR);
     }
   };
@@ -664,17 +668,25 @@ const Timetable = () => {
             ? null
             : setGenerateTimetableError("")
         }
-        style={generateTimetableError ? {} : { display: "none" }}
+        style={
+          generateTimetableError || isTimetableGenerating
+            ? {}
+            : { display: "none" }
+        }
       >
-        <div className="error-modal">
-          <span className="material-symbols-outlined close-modal">close</span>
-          <h2 className="timetable-generate-error-title">
-            {TIMETABLE_ERROR_TITLE}
-          </h2>
-          <h3 className="timetable-generate-error-message">
-            {generateTimetableError}
-          </h3>
-        </div>
+        {isTimetableGenerating ? (
+          <div className="loader timetable-loader"></div>
+        ) : (
+          <div className="error-modal">
+            <span className="material-symbols-outlined close-modal">close</span>
+            <h2 className="timetable-generate-error-title">
+              {TIMETABLE_ERROR_TITLE}
+            </h2>
+            <h3 className="timetable-generate-error-message">
+              {generateTimetableError}
+            </h3>
+          </div>
+        )}
       </div>
 
       <section

--- a/frontend/src/components/Timetable.jsx
+++ b/frontend/src/components/Timetable.jsx
@@ -401,7 +401,9 @@ const Timetable = () => {
   const generateTimetable = async () => {
     try {
       const response = await fetch(
-        `${import.meta.env.VITE_BASE_URL}${Path.TIMETABLE}${GENERATE_PATH}`,
+        `${import.meta.env.VITE_BASE_URL}${
+          Path.TIMETABLE
+        }${GENERATE_PATH}${ID_QUERY_PARAM}${timetable?.id}`,
         {
           method: "POST",
           credentials: "include",

--- a/frontend/src/components/exploreCourseList/ExploreCourse.jsx
+++ b/frontend/src/components/exploreCourseList/ExploreCourse.jsx
@@ -41,6 +41,8 @@ const ExploreCourse = (props) => {
   const CHANGE_CART_ERROR_MESSAGE = "Error updating shopping cart";
   const CHANGE_FAVORITES_ERROR_MESSAGE = "Error updating favorites";
   const REJECT_COURSE_ERROR_MESSAGE = "Error rejecting recommendation";
+  const PREREQUISITE_AMOUNT = "Minimum Prerequisites: ";
+  const COREQUISITE_AMOUNT = "Minimum Corequisites: ";
 
   const renderClassHours = (classType, hours) => {
     let backgroundColor;
@@ -80,6 +82,15 @@ const ExploreCourse = (props) => {
             </li>
           ))}
         </ul>
+      </h4>
+    );
+  };
+
+  const renderRequirementAmounts = (requirementAmount, requirementMessage) => {
+    return (
+      <h4 className="explore-course-heading">
+        {requirementMessage}
+        <span className="explore-course-heading-item">{requirementAmount}</span>
       </h4>
     );
   };
@@ -292,7 +303,19 @@ const ExploreCourse = (props) => {
           {renderMinorOrCertificate(props.course, CERTIFICATE)}
 
           {renderCourseRequirements(props.course.prerequisites, PREREQUISITES)}
+          {props.course.prerequisiteAmount !== 0
+            ? renderRequirementAmounts(
+                props.course.prerequisiteAmount,
+                PREREQUISITE_AMOUNT
+              )
+            : null}
           {renderCourseRequirements(props.course.corequisites, COREQUISITES)}
+          {props.course.corequisiteAmount !== 0
+            ? renderRequirementAmounts(
+                props.course.corequisiteAmount,
+                COREQUISITE_AMOUNT
+              )
+            : null}
           {renderCourseRequirements(props.course.exclusions, EXCLUSIONS)}
           {renderCourseRequirements(
             props.course.recommendedPrep,

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -415,6 +415,7 @@ export const DESCRIPTION_PATH = "/description";
 export const DESIGNATION_PATH = "/designation";
 export const CONFLICT_STATUS_PATH = "/conflict-status";
 export const RECOMMENDATIONS_PATH = "/recommendations";
+export const GENERATE_PATH = "/generate";
 export const ID_QUERY_PARAM = "?id=";
 
 export const YES = "Yes";

--- a/frontend/src/utils/requirementsCheck.js
+++ b/frontend/src/utils/requirementsCheck.js
@@ -1,23 +1,26 @@
 import {
   COMPUTER_AREAS,
   COMPUTER,
-  ELECTRICAL,
-  initialErrors,
-} from "./constants";
+  ELECTRICAL
+} from "./constants.js";
 
 const ECE472_CODE = "ECE472H1";
 const PREREQ_INDEX = 0;
 const COREQ_INDEX = 1;
 const EXCLUSIONS_INDEX = 2;
 
-const listAllCoursesFromAnArea = (area, courses) => {
-  let areaCourses = { area, courses: [] };
-
-  courses.forEach((courseObject) => {
-    if (courseObject.course.area.includes(area))
-      areaCourses.courses.push(courseObject.course);
+export const updateAreaCoursesList = (courseObject, areaCoursesList) => {
+  courseObject.course.area.forEach((area) => {
+    areaCoursesList
+      .find((areaCourseList) => areaCourseList.area === area)
+      ?.courses?.push(courseObject.course);
   });
-  return areaCourses;
+};
+
+export const initializeAreaCoursesList = (areaCourseList, kernelAreas) => {
+  kernelAreas.forEach((area) => {
+    areaCourseList.push({ area, courses: [] });
+  });
 };
 
 const generateCourseString = (course) => {
@@ -167,8 +170,9 @@ export const areRequirementsMet = (
   let kernelCourses = [];
   let depthCourses = [];
 
-  timetable?.kernel.forEach((area) => {
-    areaCoursesList.push(listAllCoursesFromAnArea(area, timetable.courses));
+  initializeAreaCoursesList(areaCoursesList, timetable.kernel);
+  timetable.courses.forEach((courseObject) => {
+    updateAreaCoursesList(courseObject, areaCoursesList);
   });
 
   // Look at kernel areas that are not also depth areas


### PR DESCRIPTION
In this PR, I completed the following:

Loading & error message when generating timetable

- Minimize shopping cart list height to become a scrollable container within timetable page (to avoid excessively long page relative to size of timetable course slots
- Implement pop-up modal displaying error message for errors from generating timetable; can exit via clicking x-button or background around modal
- Implement loader animation while generating timetable, disabling all other user actions until generation is complete or error is thrown
- Implement logic to display prerequisite & corequisite minimum course amounts on course display objects so users understand how many out of each course requirement list they must fulfill

Implement partial timetable generation logic

- Implement fetch logic on frontend to call generate timetable function
- Implement checks for 20 or more courses before & after refining shopping cart; refining shopping cart involves removing courses where its minimum requirements are not met by other shopping cart courses
- Implement logic to gather timetable data depending on timetable currently generating course arrangements for
- Implement logic to determine if not enough courses are available in each ECE kernel/depth area to generate recommendations by finding if at least one combination of courses is possible such that there are 3 courses per depth/kernel area & 1 course per non-depth kernel area, for a total of 8 across 4 areas (2 non-depth kernel areas & 2 depth/kernel areas)
- Implement logic to determine if attempt to add course to an area is legal & will still make it possible for remaining kernel/depth courses to be assigned; used when generating a valid combination of kernel/depth courses
- Implement logic to sort areas by least to greatest extra courses (relative to the required courses - 1 for non-depth, 3 for depth area) to first focus on those with least flexibility
- Implement hash map to determine requirement support score for each kernel/depth area course (number of courses that it meets at least 1 requirement for)
- Refactor logic determining a combination of courses to satisfy kernel/depth areas to be used in initial check to ensure at least 1 option is available then in timetable generation to check various combinations with a time limit of 5 seconds
- Implement logic to order courses in each area with those meeting less of other kernel areas (so minimal flexibility) with high requirement support scores being favored to explore first in kernel/depth course combination checks

Backend test cases

- Before or after refining shopping cart, under 20 courses - error thrown & shown on frontend
- Over 20 courses, but a course is missing its requirements from the shopping cart list - it gets excluded in the refined list, as shown with Random Processes
<img width="743" height="265" alt="Screenshot 2025-07-14 at 5 05 01 PM" src="https://github.com/user-attachments/assets/1dca6e31-984b-4d4d-9f82-6d88169b8b1c" />
<img width="351" height="673" alt="Screenshot 2025-07-14 at 5 04 48 PM" src="https://github.com/user-attachments/assets/a554fc4e-af45-40db-80c4-fa6576bdf7ce" />

- Course has more prerequisites/corequisites than needed - display to user all course requirements, but explicitly state how many from the total list are needed to meet the requirement
- Under 1 (for non-depth) or 3 (for depth) courses per area after considering overlaps with other areas - will give error sharing not enough unique courses to meet all area requirements
- Only a single course in an area - sorting does not crash when sorting course list & will add this course to total kernel/depth courses otherwise throw error (as the area requires this course & if this is not possible, then the current shopping cart cannot be used)
- 2 non-depth kernel areas but they share the same single course - error thrown & shown sharing not enough courses
- 1 area has 1 more course than needed (2 for non-depth, 4 for depth), and shares 1 course with another area containing just enough courses (1 for non-depth, 3 for depth) - will ensure the shared course is given to the area with just enough courses to avoid a wrongful error
- Kernel has 2 shared courses, each belonging to one other area (each shared course is used by a different area); one of those areas needs it, while other does not - ensure the course is given to the area that needs it, only take other shared course if the area needs it when looping over courses & still have not met requirements (1 course for non-depth, 3 for depth)
- Kernel has 2 shared courses, each belonging to different areas; those areas do not have immediate need for the course, but taking the wrong course could cause an invalid combination. Examples shown below indicate in bold what course is selected (by id) that would make it incorrect, then the correct version my algorithm chooses
Area 1 (depth): **1**, 9, **6, 7**
Area 2 (non-depth): 1, **4**
Area 3 (non-depth): 1, 4 (error)
Area 4 (depth): **2, 3, 5**

Corrected:
Area 1 (depth): 1, **9, 6, 7**
Area 2 (non-depth): **1**, 4
Area 3 (non-depth): 1, **4**
Area 4 (depth): **2, 3, 5**

Is legal checks for edge case where haver enough unique courses, but too many duplicated across 2+ areas where there is not enough unique across these 2+ areas to meet the minimum requirements:
Example:
Area 1 (depth): 1, **9, 6, 4**
Area 2 (non-depth): 1, **5**, 7
Area 3 (non-depth): 1, 4, 6 (or just 4) **(error)**
Area 4 (depth): **1,** 2, **3, 5**

Corrected:
Area 1 (depth): 1, **9, 6, 4**
Area 2 (non-depth): 1, **5**, 7
Area 3 (non-depth): **1,** 4, 6 (or just 4)
Area 4 (depth): 1, **2,** **3, 5**

Example
Area 1 (non-depth): 1, 3 **(error)**
Area 2 (depth): 1, **4, 5, 6**, 7
Area 3 (non-depth): 1, 3, 4 **(error)**
Area 4 (depth): **1, 3,** 4, **8**, 9

Solution: 
Area 1 (non-depth): **1,** 3
Area 2 (depth): 1, 4, **5, 6, 7**
Area 3 (non-depth): 1, **3**, 4
Area 4 (depth): 1, 3, **4, 8, 9**

Example
1: 3, **2, 4, 5** 
2: **1,** 2, 5, 6, 8
3: 1, 3, 4, 5, 6, 7 **(error)**
4 (non-depth): **3**, 4

Solution
1 (depth: 3, **2, 4, 5** 
2 (non-depth): 1, 2, 5, 6, **8**
3 (depth): **1,** 3, 4, 5, **6, 7**
4 (non-depth): **3,** 4

- Have enough courses (e.g. 3 ENERGY_ELECTROMAGNETICS courses for depth area - ECE520, ECE320, ECE349) but less than required amount (only ECE349) are available to use due to their course requirements not being met by other cart courses - error given & shown to user; then once add needed course requirements (ECE314) - not given error; **this is shown in video walkthrough below**
- Add all courses with ECE335 as a prereq/coreq (total 3) but one does not have prerequisites/corequisites met by other shopping cart courses - see count of 2 in hashmap for other courses ECE335 meets requirements for because must consider only courses with all its prereq/coreq present in other cart courses


Frontend

- Course has zero prerequisites/corequisites - show nothing instead of number 0 for prerequisite/corequisite amounts
<div>
    <a href="https://www.loom.com/share/d06b9fb8d9884051b4cd2d3a996e7e4a">
      <p>Frontend Test Cases - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/d06b9fb8d9884051b4cd2d3a996e7e4a">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/d06b9fb8d9884051b4cd2d3a996e7e4a-5830fc9438bba1fd-full-play.gif">
    </a>
  </div>
