### PR TITLE
Enhance usability of dropdown menu items

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -821,10 +821,11 @@ footer {
   transform: rotateY(180deg);
 }
 
-.explore-arrow {
+.explore-arrow,
+.dropdown-arrow {
   color: var(--dark-gray);
   font-size: var(--title-size);
-  background-color: var(--background-light);
+  background-color: transparent;
   cursor: pointer;
   position: relative;
 }
@@ -834,7 +835,8 @@ footer {
   text-align: end;
 }
 
-.explore-arrow:hover {
+.explore-arrow:hover,
+.dropdown-arrow:hover {
   color: var(--main-color);
 }
 
@@ -1390,7 +1392,7 @@ footer {
 }
 
 .reject-icon:hover {
-  color: var(--error-red)
+  color: var(--error-red);
 }
 
 .recommendation-score {
@@ -1420,7 +1422,7 @@ footer {
   height: 100vh;
   background-color: rgba(0, 0, 0, 0.386);
   z-index: 2;
-  display:flex;
+  display: flex;
 }
 
 .error-modal {
@@ -1463,5 +1465,25 @@ footer {
 }
 
 .close-modal:hover {
-  color: var(--dark-gray)
+  color: var(--dark-gray);
+}
+
+.dropdown-arrow {
+  font-size: var(--subtitle-size);
+  position: absolute;
+}
+
+.dropdown-arrow-left {
+  margin-left: -35px;
+}
+
+.dropdown-arrow-right {
+  right: 0;
+  top: 0;
+  margin-right: -35px;
+}
+
+.dropdown-items-outer-container {
+  width: fit-content;
+  position: relative;
 }

--- a/frontend/src/components/DropdownItems.jsx
+++ b/frontend/src/components/DropdownItems.jsx
@@ -1,12 +1,64 @@
+import { useState, useRef } from "react";
+import { changeScroll } from "../utils/changeScroll";
+
 const DropdownItems = (props) => {
+  const [elementScrolledTo, setElementScrolledTo] = useState(0);
+  const courseOuterContainerRefList = useRef([]);
+  const courseContainerRef = useRef();
+
   return (
-    <div className="dropdown-items-container">
-      {props.selectedItems.map((item, index) => (
-        <div className="dropdown-item-container" key={index}>
-          {!Array.isArray(props.allItems) ? props.allItems[item] : item}
-          <span className="material-symbols-outlined dropdown-item-x" onClick={() => props.removeItem(item)}>close_small</span>
-        </div>
-      ))}
+    <div className="dropdown-items-outer-container">
+      <span
+        className="material-symbols-outlined dropdown-arrow dropdown-arrow-left"
+        style={props.selectedItems.length === 0 ? { display: "none" } : {}}
+        onClick={() =>
+          changeScroll(
+            -1,
+            courseContainerRef,
+            courseOuterContainerRefList,
+            elementScrolledTo,
+            setElementScrolledTo,
+            props.selectedItems.length
+          )
+        }
+      >
+        arrow_left
+      </span>
+      <div className="dropdown-items-container" ref={courseContainerRef}>
+        {props.selectedItems.map((item, index) => (
+          <div
+            className="dropdown-item-container"
+            key={index}
+            ref={(ref) => {
+              courseOuterContainerRefList.current[index] = ref;
+            }}
+          >
+            {!Array.isArray(props.allItems) ? props.allItems[item] : item}
+            <span
+              className="material-symbols-outlined dropdown-item-x"
+              onClick={() => props.removeItem(item)}
+            >
+              close_small
+            </span>
+          </div>
+        ))}
+      </div>
+      <span
+        className="material-symbols-outlined dropdown-arrow dropdown-arrow-right"
+        style={props.selectedItems.length === 0 ? { display: "none" } : {}}
+        onClick={() =>
+          changeScroll(
+            1,
+            courseContainerRef,
+            courseOuterContainerRefList,
+            elementScrolledTo,
+            setElementScrolledTo,
+            props.selectedItems.length
+          )
+        }
+      >
+        arrow_right
+      </span>
     </div>
   );
 };

--- a/frontend/src/components/exploreCourseList/ExploreCourseList.jsx
+++ b/frontend/src/components/exploreCourseList/ExploreCourseList.jsx
@@ -1,27 +1,26 @@
 import { useRef, useState } from "react";
 import ExploreCourse from "./ExploreCourse";
+import { changeScroll } from "../../utils/changeScroll";
 
 const ExploreCourseList = (props) => {
   const [elementScrolledTo, setElementScrolledTo] = useState(0);
   const courseOuterContainerRefList = useRef([]);
   const courseContainerRef = useRef();
 
-  const changeScroll = (increment) => {
-    const newElementIndex = elementScrolledTo + increment;
-    if (newElementIndex < 0 || newElementIndex >= props.courses.length) return;
-
-    courseContainerRef.current.scrollTo({
-      left: courseOuterContainerRefList.current[newElementIndex].offsetLeft,
-      behavior: "smooth",
-    });
-    setElementScrolledTo(newElementIndex);
-  };
-
   return (
     <div className="explore-course-list-container">
       <span
         className="material-symbols-outlined explore-arrow"
-        onClick={() => changeScroll(-1)}
+        onClick={() =>
+          changeScroll(
+            -1,
+            courseContainerRef,
+            courseOuterContainerRefList,
+            elementScrolledTo,
+            setElementScrolledTo,
+            props.courses.length
+          )
+        }
       >
         arrow_left
       </span>
@@ -38,7 +37,16 @@ const ExploreCourseList = (props) => {
       </div>
       <span
         className="material-symbols-outlined explore-arrow explore-right-arrow"
-        onClick={() => changeScroll(1)}
+        onClick={() =>
+          changeScroll(
+            1,
+            courseContainerRef,
+            courseOuterContainerRefList,
+            elementScrolledTo,
+            setElementScrolledTo,
+            props.courses.length
+          )
+        }
       >
         arrow_right
       </span>

--- a/frontend/src/utils/changeScroll.js
+++ b/frontend/src/utils/changeScroll.js
@@ -1,0 +1,17 @@
+export const changeScroll = (
+  increment,
+  crsContainerRef,
+  crsOuterContainerRefList,
+  elementScrolledTo,
+  setElementScrolledTo,
+  coursesLength
+) => {
+  const newElementIndex = elementScrolledTo + increment;
+  if (newElementIndex < 0 || newElementIndex >= coursesLength) return;
+
+  crsContainerRef.current.scrollTo({
+    left: crsOuterContainerRefList.current[newElementIndex].offsetLeft,
+    behavior: "smooth",
+  });
+  setElementScrolledTo(newElementIndex);
+};


### PR DESCRIPTION
Enhance usability of dropdown menu items

- After discussing with Lokesh a PR comment where he initially thought the dropdown menu items were cut off after reaching the end of the div, agreed to implement arrows to indicate user can scroll with functionality to move scroll bar left/right after clicking these arrows
- Enhanced styling of left/right arrows for course list on Explore page to remove background color with transparent background
- Refactor scrolling logic into utils file to be utilized by both dropdown menu items & course lists in explore/shopping cart pages
- Modify styling of left/right arrows depending on if dropdown is used in create account or within logged in pages (e.g. in timetable creation) to ensure they render as expected

<div>
    <a href="https://www.loom.com/share/b914bff460914255acfbeb02360a5e5c">
      <p>Frontend (of arrows) - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/b914bff460914255acfbeb02360a5e5c">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/b914bff460914255acfbeb02360a5e5c-e77a88b19bf40142-full-play.gif">
    </a>
  </div>
