### PR TITLE
Implement TC2 kernel/depth course brainstorming logic & additional handling of edge cases

### DIFF
--- a/frontend/src/components/Timetable.jsx
+++ b/frontend/src/components/Timetable.jsx
@@ -664,7 +664,8 @@ const Timetable = () => {
       <div
         className="error-modal-container"
         onClick={(event) =>
-          event.target.className === "error-modal"
+          !event.target.className.includes("error-modal-container") &&
+          !event.target.className.includes("close-modal")
             ? null
             : setGenerateTimetableError("")
         }


### PR DESCRIPTION
In this PR, I completed the following:

- Addressed various edge cases mentioned in #23 more completely (e.g. ensuring checks for a valid combination of kernel/depth courses avoid computation time wasted by catching dead-ends earlier on)
- Implement logic to explore major combinations of kernel/depth courses (combinations of 8 courses such that each combination differs by at least 3 courses); exploration done via incremental increases in offset & randomized offset of the index to start looking at courses in each kernel/depth area's course list
- Implement logic to explore minor permutations around the top current combination, using restricted & unrestricted randomized offsets to explore new combinations with 2 or less courses differing from the top combination; as the top combination changes, the 2 or less course difference requirement updates to work on the new combination
- Below shows list of [minor permutation offsets using restricted randomization], [top offsets from top combination], [maximum offset values for each area]
<img width="586" height="551" alt="Screenshot 2025-07-16 at 8 17 11 PM" src="https://github.com/user-attachments/assets/a4f75723-ff4f-473e-8c12-b7b11aab60a9" />

Key notes

- Going from major combinations to minor permutations enables me to do deeper analysis around a combination with the strongest performance (to increase chances of finding the global maxima, or a top local maxima), while not overlapping with previously explored combinations
- After attempting different minor permutations on same major combination, the deployed randomized strategy leads to consistent results (while the offsets are randomized, they converge to the same number of potential kernel/depth course combinations explored in 5 seconds)
- **Logic behind when to switch from incremental to unrestricted random offsets for major combinations**: explored different combos of cart courses, determined how many kernel/depth combinations were found before/after randomized offsets to determine what threshold makes searching randomized offsets worth it; found number of potential combinations tends to be around the total courses eligible for the 8 kernel/depth courses (e.g. 40 combinations for 40 courses) but drastically decreases around 20-30 courses (nearing about 5); if under threshold after incremental offset changes, in both cases, a considerable increase occurred when switching to random offsets

Edge Case Examples

- Randomized offsets for the major combination phase equal the maximum possible offsets for each area (which is the condition to trigger randomized offsets to begin when currently on incremented offsets) - ensure this does not reset the process
- Non-depth kernel areas can have offsets at the last index in their course list, while depth/kernel areas can have it at the 3rd-last (due to needing 3 courses) - ensure randomized & incremented offsets are between 0 & these maximums for each area
- Topcombinationindex === 0 - do not exit after finding major combinations, even with this falsey value because its non-null
- After reach maximum failed attempts for major & minor combinations, do not produce another set of offsets using the current strategy, switching strategies after reach maximum fails
- End major permutations & no valid combination found - returns error, does not crash attempting to complete minor permutation logic

