### PR TITLE
Implement logic to order courses to add to timetable by how easy they are to add to the current timetable state

### DIFF
--- a/backend/api/course-model.js
+++ b/backend/api/course-model.js
@@ -2,44 +2,62 @@ const { PrismaClient } = require("@prisma/client");
 
 const prisma = new PrismaClient();
 
+const prereqCoreqNestedDetailsNeeded = {
+  code: true,
+  title: true,
+  id: true,
+  prerequisites: true,
+  corequisites: true,
+  prerequisiteAmount: true,
+  corequisiteAmount: true,
+  exclusions: true,
+};
+
+const prereqCoreqDetailsNeeded = {
+  code: true,
+  title: true,
+  id: true,
+  prerequisites: {
+    select: prereqCoreqNestedDetailsNeeded,
+  },
+  corequisites: {
+    select: prereqCoreqNestedDetailsNeeded,
+  },
+  prerequisiteAmount: true,
+  corequisiteAmount: true,
+  exclusions: true,
+};
+
 const getAllCourses = async () => {
   return await prisma.course.findMany({
-      include: {
-        minorsCertificates: true,
-        prerequisites: {
-          select: {
-            code: true,
-            title: true,
-            id: true
-          },
-        },
-        corequisites: {
-          select: {
-            code: true,
-            title: true,
-            id: true
-          },
-        },
-        exclusions: {
-          select: {
-            code: true,
-            title: true,
-            id: true
-          },
-        },
-        recommendedPrep: {
-          select: {
-            code: true,
-            title: true,
-            id: true
-          },
-        },
-        inUserShoppingCart: true,
-        inUserFavorites: true,
-        skillsInterests: true
+    include: {
+      minorsCertificates: true,
+      prerequisites: {
+        select: prereqCoreqDetailsNeeded,
       },
-    });
-}
+      corequisites: {
+        select: prereqCoreqDetailsNeeded
+      },
+      exclusions: {
+        select: {
+          code: true,
+          title: true,
+          id: true,
+        },
+      },
+      recommendedPrep: {
+        select: {
+          code: true,
+          title: true,
+          id: true,
+        },
+      },
+      inUserShoppingCart: true,
+      inUserFavorites: true,
+      skillsInterests: true,
+    },
+  });
+};
 
 module.exports = {
   async findCourses(userId) {

--- a/backend/api/course-model.js
+++ b/backend/api/course-model.js
@@ -6,8 +6,16 @@ const prereqCoreqNestedDetailsNeeded = {
   code: true,
   title: true,
   id: true,
-  prerequisites: true,
-  corequisites: true,
+  prerequisites: {
+    include: {
+      exclusions: true,
+    },
+  },
+  corequisites: {
+    include: {
+      exclusions: true,
+    },
+  },
   prerequisiteAmount: true,
   corequisiteAmount: true,
   exclusions: true,
@@ -36,7 +44,7 @@ const getAllCourses = async () => {
         select: prereqCoreqDetailsNeeded,
       },
       corequisites: {
-        select: prereqCoreqDetailsNeeded
+        select: prereqCoreqDetailsNeeded,
       },
       exclusions: {
         select: {


### PR DESCRIPTION
In this PR, I implemented the following:

- Enhance refined shopping cart logic to recheck all current cart courses as soon as any one is removed from the cart due to its minimum coreq/prereq not being found elsewhere in the cart
- Implement easy to enroll logic looking at 2 layers of requirements (a course's prerequisites/corequisites/exclusions, then its prerequisites/corequisites' prerequisites/corequisites/exclusions) to find the minimum possible count of additional courses needing to be enrolled in to ensure that course has all of its requirements met

Key Notes

- High-level comments were added to abstract away the detailed & thorough thinking behind each chunk of complex code & to apply feedback received to make PRs more concise/focused 
- Added exclusion influence factor that worsens the score for any courses with a higher frequency of exclusion conflicts with other refined shopping cart courses; but if there are direct exclusion conflicts, that specific course will not be considered in the timetable

Example Edge cases

- Only possible prerequisites/corequisites to meet a course's requirements are those that have exclusion conflicts with existing shopping cart courses being found in timetable - ignore the course with a -1 invalid score
<img width="653" height="320" alt="Screenshot 2025-07-17 at 8 53 43 PM" src="https://github.com/user-attachments/assets/ca3cdfc4-d83d-417e-a2a7-41b108002f71" />

- Handle sorting + filtering after finding easy to enroll score for various cases: When a course's prereq are both valid, it has zero prereq, when the prereq amount is less than all the available courses, and when prereq available is less than the prereq amount required (potentially lost 1+ prereqs due to exclusion issues with existing timetable courses); below shows case with more than needed prereqs relative to the prereq amount needed, but still lost 1 (relative to the initial course.prerequisites due to exclusion conflicts that gave it a -1 easy to enroll score that was filtered out)
<img width="818" height="506" alt="Screenshot 2025-07-17 at 9 07 38 PM" src="https://github.com/user-attachments/assets/256aaaa4-f2fc-4574-9487-209fcd5b0ed4" />
