### PR TITLE
Implement logic to display to user top-ranked timetable

### DIFF
--- a/backend/api/server.js
+++ b/backend/api/server.js
@@ -531,7 +531,7 @@ server.post(Path.TIMETABLE, async (req, res, next) => {
       throw new Error(INVALID_TIMETABLE_COURSE_DETAILS_ERROR);
     }
 
-    await User.addTimetableCourse(
+    await Timetable.addTimetableCourse(
       timetableCourseData?.term,
       timetableCourseData?.position,
       timetableCourseData?.courseId,

--- a/backend/api/server.js
+++ b/backend/api/server.js
@@ -323,8 +323,11 @@ server.patch(`${Path.EXPLORE}${CART_PATH}`, async (req, res, next) => {
       throw new Error(INVALID_COURSE_ID);
 
     const userId = Number(req.session?.user?.id);
-    const updatedCourse = await User.toggleCourseInShoppingCart(userId, Number(courseId));
-    res.status(200).json({course: updatedCourse});
+    const updatedCourse = await User.toggleCourseInShoppingCart(
+      userId,
+      Number(courseId)
+    );
+    res.status(200).json({ course: updatedCourse });
   } catch (err) {
     next(err);
   }
@@ -337,8 +340,11 @@ server.patch(`${Path.EXPLORE}${FAVORITES_PATH}`, async (req, res, next) => {
       throw new Error(INVALID_COURSE_ID);
 
     const userId = Number(req.session?.user?.id);
-    const updatedCourse = await User.toggleCourseInFavorites(userId, Number(courseId));
-    res.status(200).json({course: updatedCourse});
+    const updatedCourse = await User.toggleCourseInFavorites(
+      userId,
+      Number(courseId)
+    );
+    res.status(200).json({ course: updatedCourse });
   } catch (err) {
     next(err);
   }
@@ -351,8 +357,11 @@ server.patch(`${Path.EXPLORE}${REJECT_PATH}`, async (req, res, next) => {
       throw new Error(INVALID_COURSE_ID);
 
     const userId = Number(req.session?.user?.id);
-    const updatedCourse = await User.rejectRecommendation(userId, Number(courseId));
-    res.status(200).json({course: updatedCourse});
+    const updatedCourse = await User.rejectRecommendation(
+      userId,
+      Number(courseId)
+    );
+    res.status(200).json({ course: updatedCourse });
   } catch (err) {
     next(err);
   }
@@ -573,7 +582,13 @@ server.get(`${Path.EXPLORE}${RECOMMENDATIONS_PATH}`, async (req, res, next) => {
   try {
     const userId = Number(req.session?.user?.id);
     const courses = await Course.findCourses(userId);
-    const recommendedCourses = await findRecommendedCourses(courses, userId, true);
+    const recommendedCourses = await findRecommendedCourses(
+      courses,
+      userId,
+      true,
+      false,
+      []
+    );
     res.status(200).json({ recommendedCourses });
   } catch (err) {
     next(err);

--- a/backend/api/timetable-model.js
+++ b/backend/api/timetable-model.js
@@ -43,4 +43,41 @@ module.exports = {
       throw new Error();
     }
   },
+
+  async addTimetableCourse(term, position, courseId, timetableId, userId) {
+    await prisma.user.update({
+      where: {
+        id: userId,
+      },
+      data: {
+        timetables: {
+          update: {
+            where: {
+              id: timetableId,
+            },
+            data: {
+              courses: {
+                upsert: {
+                  where: {
+                    courseId_timetableId: { courseId, timetableId },
+                  },
+                  create: {
+                    term,
+                    position,
+                    course: {
+                      connect: { id: courseId },
+                    },
+                  },
+                  update: {
+                    term,
+                    position,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+  },
 };

--- a/backend/api/user-model.js
+++ b/backend/api/user-model.js
@@ -444,41 +444,4 @@ module.exports = {
       },
     });
   },
-
-  async addTimetableCourse(term, position, courseId, timetableId, userId) {
-    await prisma.user.update({
-      where: {
-        id: userId,
-      },
-      data: {
-        timetables: {
-          update: {
-            where: {
-              id: timetableId,
-            },
-            data: {
-              courses: {
-                upsert: {
-                  where: {
-                    courseId_timetableId: { courseId, timetableId },
-                  },
-                  create: {
-                    term,
-                    position,
-                    course: {
-                      connect: { id: courseId },
-                    },
-                  },
-                  update: {
-                    term,
-                    position,
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-    });
-  },
 };

--- a/backend/tests/recommendCourses.test.js
+++ b/backend/tests/recommendCourses.test.js
@@ -56,7 +56,9 @@ test("the recommendation function returns list of course objects with a valid co
   const recommendedCourses = await findRecommendedCourses(
     courses,
     userId,
-    true
+    true,
+    false,
+    []
   );
   expect(recommendedCourses).toEqual(
     courses.length === cartCourses.length
@@ -76,7 +78,9 @@ test("the recommendation function returns list with length of at least the rolli
   const recommendedCourses = await findRecommendedCourses(
     courses,
     userId,
-    true
+    true,
+    false,
+    []
   );
   expect(recommendedCourses.length).toBeGreaterThanOrEqual(
     coursesNotInCart.length >= NUM_COURSES_ROLLING_AVERAGE * 2

--- a/backend/utils/courseData.js
+++ b/backend/utils/courseData.js
@@ -685,7 +685,6 @@ export const COURSE_DATA = [
       "ECE231H1",
       "ECE360H1",
       "ECE320H1",
-      "ECE357H1",
     ],
     corequisites: [],
     exclusions: [],

--- a/backend/utils/generateTimetable.js
+++ b/backend/utils/generateTimetable.js
@@ -1,5 +1,6 @@
 import Course from "../api/course-model.js";
 import User from "../api/user-model.js";
+import Timetable from "../api/timetable-model.js";
 import { createIdListFromObjectList } from "./findRecommendedCourses.js";
 import {
   initializeAreaCoursesList,
@@ -1433,5 +1434,35 @@ export const generateTimetable = async (userId, timetableId) => {
       timetableToRecommend = topTimetable.courses;
     }
   }
+
+  if (timetableToRecommend) {
+    await addTimetable(timetableToRecommend, timetable, userId);
+    return;
+  }
   throw new Error(NO_TIMETABLE_POSSIBLE);
+};
+
+// Remove all existing timetable courses & replace them with the new valid timetable courses in the proper term & position locations
+const addTimetable = async (timetableToRecommend, timetable, userId) => {
+  await Promise.all(
+    timetable.courses.map(async (course) => {
+      await Timetable.deleteTimetableCourse(
+        course.courseId,
+        timetable.id,
+        userId
+      );
+    })
+  );
+
+  await Promise.all(
+    timetableToRecommend.map(async (timetableCourse) => {
+      await Timetable.addTimetableCourse(
+        Number(timetableCourse.term),
+        timetableCourse.position,
+        timetableCourse.id,
+        timetable.id,
+        userId
+      );
+    })
+  );
 };

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -452,3 +452,5 @@ export const initialErrors = [
     errors: [],
   },
 ];
+
+export const ECE472_CODE = "ECE472H1";

--- a/frontend/src/utils/requirementsCheck.js
+++ b/frontend/src/utils/requirementsCheck.js
@@ -1,10 +1,10 @@
 import {
   COMPUTER_AREAS,
   COMPUTER,
-  ELECTRICAL
+  ELECTRICAL,
+  ECE472_CODE
 } from "./constants.js";
 
-const ECE472_CODE = "ECE472H1";
 const PREREQ_INDEX = 0;
 const COREQ_INDEX = 1;
 const EXCLUSIONS_INDEX = 2;


### PR DESCRIPTION
In this PR, I completed the following:

- Implement logic to explore a wider variety of timetable combinations by adding a second phase to the brainstorming after adding kernel/depth courses to the timetable which explores courses with random sorting
- Implement logic to call a modified version of TC 1 scoring function & use recommendation scores for shopping cart courses to rank timetables based on the highest average recommendation score across courses per timetable
- Implement logic to replace current timetable with newly created timetable

Key Note

- A strong focus has been put towards implementing helper functions reduce long functions & avoid repetition
- Comments have been added to clarify chunks of logic of greater complexity

Edge cases/Bugfixes

- No timetable is found - return error message to user & keep existing timetable
- User clicks on generate timetable button then reloads the page - timetable generation logic still proceeds & newly created timetable populates page
- User does not have ECE472 added to shopping cart - still add to timetable if user requests timetable to be recommended in order to meet degree requirements
- Frontend requirement check logic would display 12 / 11 courses added to timetable after generating timetables - mandate ECE472 to be added, regardless if in user's shopping cart or not, to ensure courses exceeding kernel/depth are 11 in total

<div>
    <a href="https://www.loom.com/share/a6345913f9f24a41adf1ce18ebee52a4">
      <p>Frontend Walkthrough/Test Cases</p>
    </a>
    <a href="https://www.loom.com/share/a6345913f9f24a41adf1ce18ebee52a4">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/a6345913f9f24a41adf1ce18ebee52a4-edf5f9baac153906-full-play.gif">
    </a>
  </div>