### PR TITLE
Implement logic to explore timetable combinations across different kernel/depth areas & update timetable record accordingly

### DIFF
--- a/backend/api/server.js
+++ b/backend/api/server.js
@@ -28,6 +28,7 @@ const {
   REJECT_PATH,
   GENERATE_PATH,
   SELECT_PATH,
+  UPDATE_AREAS_PATH,
 } = require("../../frontend/src/utils/constants");
 const { Path } = require("../../frontend/src/utils/enums");
 
@@ -653,6 +654,27 @@ server.post(`${Path.TIMETABLE}${SELECT_PATH}`, async (req, res, next) => {
       userId
     );
     await addTimetable(courses, timetable, userId);
+    res.status(201).end();
+  } catch (err) {
+    next(err);
+  }
+});
+
+server.post(`${Path.TIMETABLE}${UPDATE_AREAS_PATH}`, async (req, res, next) => {
+  const timetableId = req.query?.id;
+  const kernelAreas = req.body?.kernel;
+  const depthAreas = req.body?.depth;
+
+  try {
+    if (!numberValid(timetableId)) throw new Error(INVALID_TIMETABLE_ID);
+    else if (
+      !isEceAreaArrayValid(kernelAreas, AMOUNT_OF_KERNEL_AREAS) ||
+      !isEceAreaArrayValid(depthAreas, AMOUNT_OF_DEPTH_AREAS)
+    )
+      throw new Error(INVALID_TIMETABLE_DETAILS_ERROR);
+
+    const userId = Number(req.session?.user?.id);
+    await User.updateTimetableAreas(userId, Number(timetableId), kernelAreas, depthAreas);
     res.status(201).end();
   } catch (err) {
     next(err);

--- a/backend/api/user-model.js
+++ b/backend/api/user-model.js
@@ -444,4 +444,25 @@ module.exports = {
       },
     });
   },
+
+  async updateTimetableAreas(userId, timetableId, kernelAreas, depthAreas) {
+    await prisma.user.update({
+      where: {
+        id: userId,
+      },
+      data: {
+        timetables: {
+          update: {
+            where: {
+              id: timetableId,
+            },
+            data: {
+              kernel: kernelAreas,
+              depth: depthAreas,
+            },
+          },
+        },
+      },
+    });
+  },
 };

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1576,3 +1576,22 @@ footer {
   width: 45px;
   align-self: center;
 }
+
+.area-changes-summary {
+  text-align: left;
+  font-size: var(--large-text-size);
+}
+
+.area-change {
+  padding-bottom: 5px;
+}
+
+.confirm-area-change-btn {
+  margin: 0;
+  align-self: center;
+  background-color: var(--background-darker-2);
+}
+
+.confirm-area-change-btn:hover {
+  background-color: var(--background-mixed);
+}

--- a/frontend/src/components/Timetable.jsx
+++ b/frontend/src/components/Timetable.jsx
@@ -21,7 +21,8 @@ import {
   CONFLICT_STATUS_PATH,
   GENERATE_PATH,
   SELECT_PATH,
-  TIMETABLE_AREAS_CHANGE_TITLE
+  TIMETABLE_AREAS_CHANGE_TITLE,
+  UPDATE_AREAS_PATH,
 } from "../utils/constants";
 import { fetchCoursesInCart } from "../utils/fetchShoppingCart";
 import ExploreCourse from "./exploreCourseList/ExploreCourse";
@@ -583,7 +584,7 @@ const Timetable = () => {
             ? areaChangesObject?.removed?.map((kernelAreaRemoved, index) => {
                 let kernelAreaAdded = areaChangesObject.added[index];
                 return (
-                  <li className="area-change">{`${ECE_AREAS[kernelAreaRemoved]} -> ${ECE_AREAS[kernelAreaAdded]}`}</li>
+                  <li key={index} className="area-change">{`${ECE_AREAS[kernelAreaRemoved]} -> ${ECE_AREAS[kernelAreaAdded]}`}</li>
                 );
               })
             : null}
@@ -599,6 +600,39 @@ const Timetable = () => {
         {renderAreaChanges(depthAreaChanges, DEPTH_AREA_CHANGES)}
       </>
     );
+  };
+
+  const updateTimetableAreas = async () => {
+    try {
+      const response = await fetch(
+        `${import.meta.env.VITE_BASE_URL}${
+          Path.TIMETABLE
+        }${UPDATE_AREAS_PATH}${ID_QUERY_PARAM}${timetable.id}`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            kernel: generatedTimetables[currentTimetableOption - 1].kernel,
+            depth: generatedTimetables[currentTimetableOption - 1].depth,
+          }),
+        }
+      );
+
+      if (response.ok) {
+        await selectTimetableOption();
+        cancelChangeAreasAttempt();
+        fetchTimetableData(timetable.id);
+      } else {
+        cancelChangeAreasAttempt();
+        setUpdateTimetableError(GENERIC_ERROR);
+      }
+    } catch (error) {
+      cancelChangeAreasAttempt();
+      setUpdateTimetableError(GENERIC_ERROR);
+    }
   };
 
   const kernelDepthToggled = () => {
@@ -966,6 +1000,7 @@ const Timetable = () => {
         closeAction={cancelChangeAreasAttempt}
         isModalDisplaying={displayUpdateAreasPopup}
         displayLoader={false}
+        updateTimetableAreas={updateTimetableAreas}
       />
 
       <section

--- a/frontend/src/components/Timetable.jsx
+++ b/frontend/src/components/Timetable.jsx
@@ -21,6 +21,7 @@ import {
   CONFLICT_STATUS_PATH,
   GENERATE_PATH,
   SELECT_PATH,
+  TIMETABLE_AREAS_CHANGE_TITLE
 } from "../utils/constants";
 import { fetchCoursesInCart } from "../utils/fetchShoppingCart";
 import ExploreCourse from "./exploreCourseList/ExploreCourse";
@@ -28,6 +29,7 @@ import TimetableCourseSummary from "./timetableCourseSummary/TimetableCourseSumm
 import { areRequirementsMet } from "../utils/requirementsCheck";
 import { updateCoursesInCart } from "../utils/updateCourses";
 import { Slider, Checkbox } from "@mui/material";
+import ErrorModal from "./errorModal/errorModal";
 
 const Timetable = () => {
   const initialTerms = [
@@ -76,6 +78,9 @@ const Timetable = () => {
     useState(DEFAULT_DURATION);
   const [anyKernelDepth, setAnyKernelDepth] = useState(false);
   const [anyDepth, setAnyDepth] = useState(false);
+  const [displayUpdateAreasPopup, setDisplayUpdateAreasPopup] = useState(false);
+  const [kernelAreaChanges, setKernelAreaChanges] = useState(null);
+  const [depthAreaChanges, setDepthAreaChanges] = useState(null);
 
   const TIMETABLE = "Timetable";
   const TIMETABLE_DESCRIPTION = "Timetable Description ";
@@ -111,6 +116,8 @@ const Timetable = () => {
   const ANY_DEPTH_QUERY_PARAM = "&anyDepth=";
   const CHOOSE_ANY_KERNEL_AND_DEPTH_AREAS = "Choose any kernel & depth areas:";
   const CHOOSE_ANY_DEPTH_AREAS = "Choose any depth areas:";
+  const KERNEL_AREA_CHANGES = "Kernel Area Changes:";
+  const DEPTH_AREA_CHANGES = "Depth Area Changes:";
 
   const filteredCoursesInCart = coursesInCart.filter(
     (course) =>
@@ -508,6 +515,92 @@ const Timetable = () => {
     }
   };
 
+  const handleTimetableSelection = () => {
+    let generatedTimetableKernelSet = new Set(
+      generatedTimetables[currentTimetableOption - 1].kernel
+    );
+    let generatedTimetableDepthSet = new Set(
+      generatedTimetables[currentTimetableOption - 1].depth
+    );
+    let existingTimetableKernelSet = new Set(timetable.kernel);
+    let existingTimetableDepthSet = new Set(timetable.depth);
+
+    let commonKernelAreas = generatedTimetableKernelSet.intersection(
+      existingTimetableKernelSet
+    );
+    let commonDepthAreas = generatedTimetableDepthSet.intersection(
+      existingTimetableDepthSet
+    );
+
+    let removedKernelAreas = commonKernelAreas.symmetricDifference(
+      existingTimetableKernelSet
+    );
+    let removedDepthAreas = commonDepthAreas.symmetricDifference(
+      existingTimetableDepthSet
+    );
+    let newKernelAreas = commonKernelAreas.symmetricDifference(
+      generatedTimetableKernelSet
+    );
+    let newDepthAreas = commonDepthAreas.symmetricDifference(
+      generatedTimetableDepthSet
+    );
+
+    if (removedKernelAreas.size !== 0 || removedDepthAreas.size !== 0) {
+      setKernelAreaChanges(
+        removedKernelAreas.size !== 0
+          ? {
+              removed: [...removedKernelAreas],
+              added: [...newKernelAreas],
+            }
+          : null
+      );
+      setDepthAreaChanges(
+        removedDepthAreas.size !== 0
+          ? { removed: [...removedDepthAreas], added: [...newDepthAreas] }
+          : null
+      );
+      setDisplayUpdateAreasPopup(true);
+    } else {
+      selectTimetableOption();
+    }
+  };
+
+  const cancelChangeAreasAttempt = () => {
+    setDisplayUpdateAreasPopup(false);
+    setKernelAreaChanges(null);
+    setDepthAreaChanges(null);
+  };
+
+  const renderAreaChanges = (areaChangesObject, changeText) => {
+    return (
+      <>
+        {areaChangesObject?.removed ? <span>{changeText}</span> : null}
+        <ul
+          style={areaChangesObject ? { display: "block" } : { display: "none" }}
+          className="area-changes-summary"
+        >
+          {areaChangesObject?.removed
+            ? areaChangesObject?.removed?.map((kernelAreaRemoved, index) => {
+                let kernelAreaAdded = areaChangesObject.added[index];
+                return (
+                  <li className="area-change">{`${ECE_AREAS[kernelAreaRemoved]} -> ${ECE_AREAS[kernelAreaAdded]}`}</li>
+                );
+              })
+            : null}
+        </ul>
+      </>
+    );
+  };
+
+  const generateAreaChangesSummary = () => {
+    return (
+      <>
+        {renderAreaChanges(kernelAreaChanges, KERNEL_AREA_CHANGES)}
+        {renderAreaChanges(depthAreaChanges, DEPTH_AREA_CHANGES)}
+      </>
+    );
+  };
+
   const kernelDepthToggled = () => {
     if (!anyKernelDepth) setAnyDepth(true);
     setAnyKernelDepth(!anyKernelDepth);
@@ -738,7 +831,7 @@ const Timetable = () => {
               <div className="timetable-options-select-container">
                 <span
                   className="material-symbols-outlined timetable-edit-icon timetable-yes"
-                  onClick={selectTimetableOption}
+                  onClick={handleTimetableSelection}
                 >
                   check_circle
                 </span>
@@ -859,34 +952,21 @@ const Timetable = () => {
         </div>
       </div>
 
-      <div
-        className="error-modal-container"
-        onClick={(event) =>
-          !event.target.className.includes("error-modal-container") &&
-          !event.target.className.includes("close-modal")
-            ? null
-            : setGenerateTimetableError("")
-        }
-        style={
-          generateTimetableError || isTimetableGenerating
-            ? {}
-            : { display: "none" }
-        }
-      >
-        {isTimetableGenerating ? (
-          <div className="loader timetable-loader"></div>
-        ) : (
-          <div className="error-modal">
-            <span className="material-symbols-outlined close-modal">close</span>
-            <h2 className="timetable-generate-error-title">
-              {TIMETABLE_ERROR_TITLE}
-            </h2>
-            <h3 className="timetable-generate-error-message">
-              {generateTimetableError}
-            </h3>
-          </div>
-        )}
-      </div>
+      <ErrorModal
+        title={TIMETABLE_ERROR_TITLE}
+        message={generateTimetableError}
+        closeAction={() => setGenerateTimetableError("")}
+        isModalDisplaying={generateTimetableError || isTimetableGenerating}
+        displayLoader={isTimetableGenerating}
+      />
+
+      <ErrorModal
+        title={TIMETABLE_AREAS_CHANGE_TITLE}
+        message={generateAreaChangesSummary()}
+        closeAction={cancelChangeAreasAttempt}
+        isModalDisplaying={displayUpdateAreasPopup}
+        displayLoader={false}
+      />
 
       <section
         className="timetable-requirements-container"

--- a/frontend/src/components/errorModal/ErrorModal.jsx
+++ b/frontend/src/components/errorModal/ErrorModal.jsx
@@ -1,0 +1,34 @@
+import { TIMETABLE_AREAS_CHANGE_TITLE } from "../../utils/constants";
+const CONFIRM = "Confirm";
+
+const ErrorModal = (props) => {
+  return (
+    <div
+      className="error-modal-container"
+      onClick={(event) =>
+        !event.target.className.includes("error-modal-container") &&
+        !event.target.className.includes("close-modal")
+          ? null
+          : props.closeAction()
+      }
+      style={props.isModalDisplaying ? {} : { display: "none" }}
+    >
+      {props.displayLoader ? (
+        <div className="loader timetable-loader"></div>
+      ) : (
+        <div className="error-modal">
+          <span className="material-symbols-outlined close-modal">close</span>
+          <h2 className="timetable-generate-error-title">{props.title}</h2>
+          <h3 className="timetable-generate-error-message">{props.message}</h3>
+          {props.title === TIMETABLE_AREAS_CHANGE_TITLE ? (
+            <button className="create-btn confirm-area-change-btn" onClick={props.updateTimetableAreas}>
+              {CONFIRM}
+            </button>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ErrorModal;

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -455,3 +455,6 @@ export const initialErrors = [
 ];
 
 export const ECE472_CODE = "ECE472H1";
+
+export const TIMETABLE_AREAS_CHANGE_TITLE =
+  "To Proceed, Timetable Areas Must Change";

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -417,6 +417,7 @@ export const CONFLICT_STATUS_PATH = "/conflict-status";
 export const RECOMMENDATIONS_PATH = "/recommendations";
 export const GENERATE_PATH = "/generate";
 export const SELECT_PATH = "/select";
+export const UPDATE_AREAS_PATH = "/update-areas";
 export const ID_QUERY_PARAM = "?id=";
 
 export const YES = "Yes";


### PR DESCRIPTION
In this PR, I completed the following:

- Implement logic to identify different kernel/depth or simply depth areas to explore beyond the ones currently included in the user's timetable configuration, based on if the user checks off the input box to want to explore different areas (ranked by areas with greatest flexibility & highest recommendation scores)
- Implement logic to identify differences between returned timetable's areas that user selects & current timetable areas, summarizing this to the user
- Implement logic to update timetable areas based on new timetable user requests to choose
- Implement error messaging if timetable area update fails to succeed
- Below illustrates the different kernel/depth combinations when considering only changes to depth areas:
<img width="519" height="783" alt="Screenshot 2025-07-21 at 5 28 36 PM" src="https://github.com/user-attachments/assets/643d4eda-7f96-40d0-aebe-d7a1d7b65363" />

- And changes to kernel/depth areas:
<img width="442" height="781" alt="Screenshot 2025-07-21 at 5 28 55 PM" src="https://github.com/user-attachments/assets/dfe87fe1-368f-4d35-81d7-f7d934870707" />

Key notes

- Refactored pop-up modal to be used both for summarizing area changes & for displaying generate timetable errors, making the logic reusable without repetition
- Ignore extra lines in 3rd commit because it is simply due to copying/pasting (with minor modifications) the error modal into a reusable component
- Constants used multiple times refactored into constants file
- While generate timetable function is over 200 lines, significantly refactored to remove duplicate code & call helper functions, but still significant amount of logic required for its functionality - believe additional helper functions would be redundant, but do let me know what you think

Error/edge cases

- User did not decide to have different kernel/depth areas explored or not to have different kernel areas explored, but unable to generate timetable - include in error messages how enabling kernel/depth and/or depth areas to be explored can successfully produce a valid timetable
- Only 1 timetable is found & it contains same kernel/depth areas as existing timetable - immediately update timetable with courses without giving the user the option to decline/accept it
- Only 1 timetable is found & it contains different kernel/depth areas as existing timetable - return to user the timetable with option to decline/accept it, similar to the scenario with 2-3 timetables
- New timetable has different kernel/depth areas than existing timetable - refetch requirements to update the kernel/depth areas being considered to meet degree requirements 

<div>
    <a href="https://www.loom.com/share/e8f0ec8f616d4ace97379cd149433e5d">
      <p>Frontend Walkthrough/Test Cases - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/e8f0ec8f616d4ace97379cd149433e5d">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/e8f0ec8f616d4ace97379cd149433e5d-ed51f6a9ddb2c487-full-play.gif">
    </a>
  </div>