### PR TITLE
Implement TC 2 Jest tests & refactoring of code to handle edge cases/PR feedback

### DIFF
--- a/backend/api/timetable-model.js
+++ b/backend/api/timetable-model.js
@@ -18,6 +18,9 @@ module.exports = {
           select: {
             id: true,
           },
+          orderBy: {
+            id: "asc",
+          },
         },
       },
     });

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -3720,16 +3720,16 @@
       }
     },
     "node_modules/express-session": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.1.tgz",
-      "integrity": "sha512-a5mtTqEaZvBCL9A9aqkrtfz+3SMDhOVUnjafjo+s7A9Txkq+SVX2DLvSp1Zrv4uCXa3lMSK3viWnh9Gg07PBUA==",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
+      "integrity": "sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==",
       "license": "MIT",
       "dependencies": {
         "cookie": "0.7.2",
         "cookie-signature": "1.0.7",
         "debug": "2.6.9",
         "depd": "~2.0.0",
-        "on-headers": "~1.0.2",
+        "on-headers": "~1.1.0",
         "parseurl": "~1.3.3",
         "safe-buffer": "5.2.1",
         "uid-safe": "~2.1.5"
@@ -3874,9 +3874,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -5269,16 +5269,16 @@
       }
     },
     "node_modules/morgan": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
-      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
+      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
       "license": "MIT",
       "dependencies": {
         "basic-auth": "~2.0.1",
         "debug": "2.6.9",
         "depd": "~2.0.0",
         "on-finished": "~2.3.0",
-        "on-headers": "~1.0.2"
+        "on-headers": "~1.1.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -5434,9 +5434,9 @@
       }
     },
     "node_modules/on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"

--- a/backend/tests/generateTimetable.test.js
+++ b/backend/tests/generateTimetable.test.js
@@ -3,7 +3,14 @@ const {
   isCoursePlacedInTimetable,
   generateCoursesWithScores,
   filterOutCoursesNotMeetingRequirements,
+  isThereValidCombination,
+  isTopTimetableDifferent,
 } = require("../utils/generateTimetable");
+const { ECE_AREAS } = require("../../frontend/src/utils/constants");
+const {
+  initializeAreaCoursesList,
+  updateAreaCoursesList,
+} = require("../../frontend/src/utils/requirementsCheck");
 const Course = require("../api/course-model");
 
 const userId = 9; // Possesses approximately 40 courses in their shopping cart
@@ -14,6 +21,7 @@ const DURATION = 5;
 const ANY_KERNEL_DEPTH = true;
 const ANY_DEPTH = true;
 const COURSE_CODE_TO_ADD = "ECE461H1";
+
 // Arbitrarily chosen due to being used to avoid placing duplicate courses in timetable (ids do not overlap with courses to add in the test) & to rank prerequisites (test focuses on valid placement)
 const ARBITRARY_KERNEL_DEPTH_COURSES = [1, 2, 3, 4, 5, 6, 7, 8];
 const TIMETABLE_OUTPUT = [
@@ -21,6 +29,60 @@ const TIMETABLE_OUTPUT = [
   { id: 44, term: "1", position: 2 }, // ECE361H1
   { id: 45, term: "2", position: 1 }, // ECE461H1
 ];
+
+const COURSE_CODES_TO_INCLUDE = new Set([
+  "ECE318H1",
+  "ECE335H1",
+  "ECE437H1",
+  "ECE424H1",
+  "ECE520H1",
+  "ECE526H1",
+  "ECE313H1",
+  "ECE568H1",
+  "ECE466H1",
+  "ECE342H1",
+  "ECE361H1",
+]);
+const FIRST_KERNEL = [
+  "HARDWARE_NETWORKS",
+  "ENERGY_ELECTROMAGNETICS",
+  "SOFTWARE",
+  "PHOTONICS_SEMICONDUCTOR",
+];
+const FIRST_DEPTH = ["HARDWARE_NETWORKS", "ENERGY_ELECTROMAGNETICS"];
+const SECOND_KERNEL = [
+  "HARDWARE_NETWORKS",
+  "ANALOG_DIGITAL",
+  "SOFTWARE",
+  "PHOTONICS_SEMICONDUCTOR",
+];
+const SECOND_DEPTH = ["HARDWARE_NETWORKS", "SOFTWARE"];
+
+const SCORE_77_TIMETABLE = {
+  courses: [
+    3, 11, 19, 22, 5, 27, 9, 46, 50, 16, 31, 7, 41, 35, 2, 53, 38, 24, 13, 44,
+  ],
+  score: 77,
+};
+const SCORE_75_TIMETABLE = {
+  courses: [
+    3, 11, 19, 22, 5, 27, 9, 49, 50, 16, 31, 17, 41, 35, 2, 53, 38, 24, 13, 21,
+  ],
+  score: 75,
+};
+const SCORE_70_TIMETABLE = {
+  courses: [
+    39, 1, 19, 22, 5, 27, 9, 46, 50, 16, 31, 7, 41, 35, 2, 53, 38, 24, 13, 40,
+  ],
+  score: 70,
+};
+const ORIGINAL_TIMETABLE = [
+  SCORE_77_TIMETABLE,
+  SCORE_75_TIMETABLE,
+  SCORE_70_TIMETABLE,
+];
+const NEW_TIMETABLE_WITH_NEW_TOP = [];
+const NEW_TIMETABLE_WITH_NO_NEW_TOP = [];
 
 const expectedCourseFields = {
   id: expect.any(Number),
@@ -101,7 +163,87 @@ test("the add course to timetable function updates timetable with a valid course
     coursesWithScores
   );
 
-  expect(timetableCourses).toEqual(
-    expect.arrayContaining(TIMETABLE_OUTPUT)
+  expect(timetableCourses).toEqual(expect.arrayContaining(TIMETABLE_OUTPUT));
+});
+
+/**
+ * While courses are identical in both function calls, the kernel/depth areas considered in each modify if the courses are valid or not
+ * The breakdown of courses among each area are summarized below:
+ * "Photonics & Semiconductor Physics": 3 (ECE318H1, ECE335H1, ECE437H1)
+ * "Electromagnetics & Energy Systems": 4 (ECE424H1, ECE520H1, ECE526H1, ECE313H1)
+ * "Analog & Digital Electronics": 2 (ECE424H1, ECE437H1)
+ * "Control, Communications & Signal Processing": 0
+ * "Computer Hardware & Computer Networks": 4 (ECE568H1, ECE466H1, ECE342H1, ECE361H1)
+ * "Software": 1 (ECE568H1)
+ *
+ * This combination of courses will be valid in the following scenario:
+ * Kernel: Computer Hardware & Computer Networks, Electromagnetics & Energy Systems, Software, Photonics & Semiconductor Physics
+ * Depth: Computer Hardware & Computer Networks, Electromagnetics & Energy Systems
+ *
+ * It will not be valid in the following scenario:
+ * Kernel: Computer Hardware & Computer Networks, Analog & Digital Electronics, Software, Photonics & Semiconductor Physics
+ * Depth: Software, Computer Hardware & Computer Networks
+ *
+ * Note that some courses are found across several areas (ECE437H1), but in a valid combination, each course can contribute to only a single area
+ *
+ * A valid combination has 1 course in each non-depth kernel area & 3 courses in each depth kernel areas; there are 2 non-depth & 2 depth areas, for a
+ * total of 4 areas & 8 courses
+ */
+test("the check for at least 1 valid kernel/depth course combination returns true for a valid set of courses & false for an invalid one", async () => {
+  let areaCourseLists = [];
+  initializeAreaCoursesList(areaCourseLists, Object.keys(ECE_AREAS));
+  const allCourses = await Course.findCourses();
+  allCourses
+    .filter((course) => COURSE_CODES_TO_INCLUDE.has(course.code))
+    .forEach((course) => {
+      updateAreaCoursesList({ course }, areaCourseLists);
+    });
+
+  let usedCourseIds = structuredClone(areaCourseLists);
+  usedCourseIds.forEach((areaObject) => {
+    areaObject.courses = new Set([]);
+  });
+  let isValidCombinationPossible1 = isThereValidCombination(
+    areaCourseLists.filter((areaCourseList) =>
+      FIRST_KERNEL.includes(areaCourseList.area)
+    ),
+    { kernel: FIRST_KERNEL, depth: FIRST_DEPTH },
+    usedCourseIds
+  );
+
+  usedCourseIds.forEach((areaObject) => {
+    areaObject.courses = new Set([]);
+  });
+  let isValidCombinationPossible2 = isThereValidCombination(
+    areaCourseLists.filter((areaCourseList) =>
+      SECOND_KERNEL.includes(areaCourseList.area)
+    ),
+    { kernel: SECOND_KERNEL, depth: SECOND_DEPTH },
+    usedCourseIds
+  );
+
+  expect([isValidCombinationPossible1, isValidCombinationPossible2]).toEqual([
+    true,
+    false,
+  ]);
+});
+
+/**
+ * Given an original timetable array, test two different timetable arrays against it:
+ * 1. A timetable array where the top option changes with different courses & a higher score
+ * 2. A timetable array where the second & third timetables change with different scores/courses, but the top remains the same
+ */
+test("the check for if two timetable arrays have a different top option correctly identifies when the top timetable remains identical & when it changes", () => {
+  const isFirstTopTimetableDifferent = isTopTimetableDifferent(
+    ORIGINAL_TIMETABLE,
+    NEW_TIMETABLE_WITH_NEW_TOP
+  );
+  const isSecondTopTimetableDifferent = isTopTimetableDifferent(
+    originalTopTimetables,
+    NEW_TIMETABLE_WITH_NO_NEW_TOP
+  );
+
+  expect([isFirstTopTimetableDifferent, isSecondTopTimetableDifferent]).toEqual(
+    [true, false]
   );
 });

--- a/backend/tests/generateTimetable.test.js
+++ b/backend/tests/generateTimetable.test.js
@@ -58,31 +58,66 @@ const SECOND_KERNEL = [
 ];
 const SECOND_DEPTH = ["HARDWARE_NETWORKS", "SOFTWARE"];
 
+const generateCourseIdList = (courseIds) => {
+  return courseIds.map((id) => {
+    return {
+      id,
+    };
+  });
+};
+
+const SCORE_78_TIMETABLE = {
+  courses: generateCourseIdList([
+    3, 7, 19, 22, 5, 27, 9, 46, 50, 16, 31, 6, 41, 33, 2, 53, 38, 24, 13, 44,
+  ]),
+  score: 78,
+};
 const SCORE_77_TIMETABLE = {
-  courses: [
+  courses: generateCourseIdList([
     3, 11, 19, 22, 5, 27, 9, 46, 50, 16, 31, 7, 41, 35, 2, 53, 38, 24, 13, 44,
-  ],
+  ]),
   score: 77,
 };
 const SCORE_75_TIMETABLE = {
-  courses: [
+  courses: generateCourseIdList([
     3, 11, 19, 22, 5, 27, 9, 49, 50, 16, 31, 17, 41, 35, 2, 53, 38, 24, 13, 21,
-  ],
+  ]),
   score: 75,
 };
 const SCORE_70_TIMETABLE = {
-  courses: [
+  courses: generateCourseIdList([
     39, 1, 19, 22, 5, 27, 9, 46, 50, 16, 31, 7, 41, 35, 2, 53, 38, 24, 13, 40,
-  ],
+  ]),
   score: 70,
 };
+const SCORE_68_TIMETABLE = {
+  courses: generateCourseIdList([
+    39, 58, 19, 22, 5, 27, 9, 46, 50, 16, 31, 7, 41, 35, 2, 53, 38, 24, 13, 42,
+  ]),
+  score: 68,
+};
+const SCORE_67_TIMETABLE = {
+  courses: generateCourseIdList([
+    39, 51, 19, 22, 5, 27, 9, 46, 50, 16, 31, 7, 41, 35, 2, 53, 38, 24, 13, 36,
+  ]),
+  score: 67,
+};
+
 const ORIGINAL_TIMETABLE = [
   SCORE_77_TIMETABLE,
   SCORE_75_TIMETABLE,
   SCORE_70_TIMETABLE,
 ];
-const NEW_TIMETABLE_WITH_NEW_TOP = [];
-const NEW_TIMETABLE_WITH_NO_NEW_TOP = [];
+const NEW_TIMETABLE_WITH_NEW_TOP = [
+  SCORE_78_TIMETABLE,
+  SCORE_75_TIMETABLE,
+  SCORE_70_TIMETABLE,
+];
+const NEW_TIMETABLE_WITH_NO_NEW_TOP = [
+  SCORE_77_TIMETABLE,
+  SCORE_68_TIMETABLE,
+  SCORE_67_TIMETABLE,
+];
 
 const expectedCourseFields = {
   id: expect.any(Number),
@@ -230,7 +265,7 @@ test("the check for at least 1 valid kernel/depth course combination returns tru
 
 /**
  * Given an original timetable array, test two different timetable arrays against it:
- * 1. A timetable array where the top option changes with different courses & a higher score
+ * 1. A timetable array where the top option changes with different courses & a higher score, but the remaining 2 are the same
  * 2. A timetable array where the second & third timetables change with different scores/courses, but the top remains the same
  */
 test("the check for if two timetable arrays have a different top option correctly identifies when the top timetable remains identical & when it changes", () => {
@@ -239,7 +274,7 @@ test("the check for if two timetable arrays have a different top option correctl
     NEW_TIMETABLE_WITH_NEW_TOP
   );
   const isSecondTopTimetableDifferent = isTopTimetableDifferent(
-    originalTopTimetables,
+    ORIGINAL_TIMETABLE,
     NEW_TIMETABLE_WITH_NO_NEW_TOP
   );
 

--- a/backend/tests/generateTimetable.test.js
+++ b/backend/tests/generateTimetable.test.js
@@ -1,0 +1,107 @@
+const {
+  generateTimetable,
+  isCoursePlacedInTimetable,
+  generateCoursesWithScores,
+  filterOutCoursesNotMeetingRequirements,
+} = require("../utils/generateTimetable");
+const Course = require("../api/course-model");
+
+const userId = 9; // Possesses approximately 40 courses in their shopping cart
+// User #9's first timetable with no courses added & the following kernel/depth areas: Photonics & Semiconductor Physics (depth), Electromagnetics & Energy Systems (depth),
+// Analog & Digital Electronics (non-depth), Control, Communications & Signal Processing (non-depth)
+const timetableId = 12;
+const DURATION = 5;
+const ANY_KERNEL_DEPTH = true;
+const ANY_DEPTH = true;
+const COURSE_CODE_TO_ADD = "ECE461H1";
+// Arbitrarily chosen due to being used to avoid placing duplicate courses in timetable (ids do not overlap with courses to add in the test) & to rank prerequisites (test focuses on valid placement)
+const ARBITRARY_KERNEL_DEPTH_COURSES = [1, 2, 3, 4, 5, 6, 7, 8];
+const TIMETABLE_OUTPUT = [
+  { id: 29, term: "1", position: 1 }, // ECE302H1
+  { id: 44, term: "1", position: 2 }, // ECE361H1
+  { id: 45, term: "2", position: 1 }, // ECE461H1
+];
+
+const expectedCourseFields = {
+  id: expect.any(Number),
+  code: expect.any(String),
+  title: expect.any(String),
+};
+const expectedCourseObjectFields = {
+  id: expect.any(Number),
+  term: expect.any(Number),
+  position: expect.any(Number),
+  course: expect.objectContaining(expectedCourseFields),
+};
+const expectedTimetableFields = {
+  score: expect.any(Number),
+  kernel: expect.arrayContaining([expect.any(String)]),
+  depth: expect.arrayContaining([expect.any(String)]),
+  courses: expect.arrayContaining([
+    expect.objectContaining(expectedCourseObjectFields),
+  ]),
+};
+
+test("the timetable generation function returns 3 valid timetable options with no restriction on kernel/depth areas used", async () => {
+  const timetableOptions = await generateTimetable(
+    userId,
+    timetableId,
+    DURATION,
+    ANY_KERNEL_DEPTH,
+    ANY_DEPTH
+  );
+  expect(timetableOptions).toEqual(
+    expect.arrayContaining([expect.objectContaining(expectedTimetableFields)])
+  );
+});
+
+/**
+ * Course being used is: ECE461H1
+ * Prerequisites: Need 1 from ["ECE361H1"]
+ * Corequisites: 0
+ * Exclusions: 0
+ *
+ * This leaves us with needing to add ECE361H1:
+ *
+ * ECE361H1
+ * Prerequisites: ["ECE286H1"] (ignored in seeding, so 0 prereq)
+ * Corequisites: Need 1 from ["ECE302H1"]
+ * Exclusions: 0
+ *
+ * This leads us to add ECE302H1:
+ * Prerequisites: ["MAT290H1", "MAT291H1", "ECE216H1"] (ignored in seeding, so 0 prereq)
+ * Corequisites: 0
+ * Exclusions: ["ECE286H1"] (ignored in seeding, so 0 exclusions)
+ *
+ * In total, to add ECE461H1, 2 other courses (ECE361H1 & ECE302H1) must be added, where ECE361H1/ECE302H1 are in the same term, while ECE461H1 is in a later term
+ *
+ * This will be using user #9's shopping cart data - with all 3 courses in the shopping cart
+ */
+test("the add course to timetable function updates timetable with a valid course & all of its nested requirements", async () => {
+  let timetableCourses = [];
+  let coursesAddedToTimetableToRecall = [];
+
+  const allCourses = await Course.findCourses();
+  const refinedShoppingCart = filterOutCoursesNotMeetingRequirements(
+    await Course.findCoursesInCart(userId)
+  );
+  let coursesWithScores = await generateCoursesWithScores(
+    allCourses,
+    userId,
+    refinedShoppingCart
+  );
+
+  isCoursePlacedInTimetable(
+    allCourses.find((course) => course.code === COURSE_CODE_TO_ADD).id,
+    refinedShoppingCart,
+    timetableCourses,
+    ARBITRARY_KERNEL_DEPTH_COURSES,
+    [],
+    coursesAddedToTimetableToRecall,
+    coursesWithScores
+  );
+
+  expect(timetableCourses).toEqual(
+    expect.arrayContaining(TIMETABLE_OUTPUT)
+  );
+});

--- a/backend/tests/recommendCourses.test.js
+++ b/backend/tests/recommendCourses.test.js
@@ -23,10 +23,10 @@ const User = require("../api/user-model");
 
 const userId = 1;
 const otherUserId = 4;
-const OTHER_USER_SCORE = 14;
+const OTHER_USER_SCORE = 15.5;
 const SHOPPING_CART_MULTIPLIER = 1;
 const COMPUTER_SECURITY_CODE = "ECE568H1";
-const TOTAL_SCORE_BOOST = 115;
+const TOTAL_SCORE_BOOST = 628;
 const expectedCourseFields = {
   id: expect.any(Number),
   description: expect.any(String),

--- a/backend/utils/generateTimetable.js
+++ b/backend/utils/generateTimetable.js
@@ -1105,7 +1105,7 @@ const updateOffsets = (
   }
 };
 
-const isThereValidCombination = (areaCourseLists, timetable, usedCourseIds) => {
+export const isThereValidCombination = (areaCourseLists, timetable, usedCourseIds) => {
   for (const areaCourseList of areaCourseLists) {
     let sortedCourseList = areaCourseList.courses.toSorted(
       (crsA, crsB) =>
@@ -1482,7 +1482,7 @@ export const generateCoursesWithScores = async (
 };
 
 // Identify if the top timetable has changed between kernel/depth course combinations to update the top combination index/offsets for the purposes of minor permutations
-const isTopTimetableDifferent = (
+export const isTopTimetableDifferent = (
   originalTopTimetables,
   timetablesToRecommend
 ) => {

--- a/backend/utils/generateTimetable.js
+++ b/backend/utils/generateTimetable.js
@@ -13,6 +13,7 @@ import {
   ECE472_CODE,
   ECE_AREAS,
   AMOUNT_OF_KERNEL_AREAS,
+  MAXIMUM_DURATION,
 } from "../../frontend/src/utils/constants.js";
 
 const MINIMUM_COURSES = 20;
@@ -50,6 +51,8 @@ const NO_TIMETABLE_POSSIBLE =
   "With the given shopping cart courses, no conflict-free combination is possible";
 const CONSIDER_ANY_KERNEL_DEPTH_MESSAGE =
   ". Consider enabling any kernel/depth area to generate a timetable";
+const CONSIDER_INCREASING_DURATION =
+  ". Also consider increasing the duration to explore more possibilities";
 const RETRIEVING_472_ERROR =
   "Something went wrong adding ECE472H1 to the timetable";
 const COURSE_RECOMMENDATION_SCORE_ERROR =
@@ -349,6 +352,34 @@ const determineValidCoursesForArea = (
   return courseCount;
 };
 
+// Ensure there are enough extra courses such that at least 3 different courses can be swapped out, otherwise do not require minimum of 3 different courses
+// per major kernel/depth area combination; ignores in the count any duplicate courses found across several areas
+const atleastThreeExtraCourses = (areaCourseLists, timetableDepth) => {
+  let differentCoursesPossibleCount = 0;
+  let allCourseIdsList = [];
+  let allCourseIdsSet = new Set([]);
+
+  areaCourseLists.forEach((areaCourseList) => {
+    differentCoursesPossibleCount += numberExtraCourses(
+      areaCourseList,
+      timetableDepth
+    );
+    allCourseIdsList = [
+      ...allCourseIdsList,
+      ...areaCourseList.courses.map((course) => course.id),
+    ];
+    allCourseIdsSet = new Set([
+      ...allCourseIdsSet,
+      ...areaCourseList.courses.map((course) => course.id),
+    ]);
+  });
+
+  differentCoursesPossibleCount -=
+    allCourseIdsList.length - allCourseIdsSet.size;
+
+  return differentCoursesPossibleCount >= 3;
+};
+
 // If there is any existing valid combination such that the difference in courses between it & the new combination is under 3 (for major permutations) or over 2
 // relative to current top combination (for minor permutations) or they are identical, conclude the combination is invalid
 const isCombinationValid = (
@@ -357,7 +388,9 @@ const isCombinationValid = (
   isExploringMajorPermutations,
   topCombinationIndex,
   currentFailedAttempts,
-  maximumFailedAttemptsWithRandomOffset
+  maximumFailedAttemptsWithRandomOffset,
+  areaCourseLists,
+  timetableDepth
 ) => {
   for (const [
     combinationIndex,
@@ -382,7 +415,8 @@ const isCombinationValid = (
       isExploringMajorPermutations &&
       differentCoursesCount < MINIMUM_DIFFERENCES_FOR_MAJOR_PERMUTATIONS &&
       currentFailedAttempts < maximumFailedAttemptsWithRandomOffset &&
-      existingCombination.valid
+      existingCombination.valid &&
+      atleastThreeExtraCourses(areaCourseLists, timetableDepth)
     ) {
       return false;
     }
@@ -786,27 +820,18 @@ const getSortedRequirements = (
   return newScoredReqList;
 };
 
-const findIdSetOfCoursesInTimetable = (
-  kernelDepthCourses,
-  timetableCourses
-) => {
-  return new Set([
-    ...kernelDepthCourses,
-    ...timetableCourses.map((course) => course.id),
-  ]);
+const findIdSetOfCoursesInTimetable = (timetableCourses) => {
+  return new Set(timetableCourses.map((course) => course.id));
 };
 
 // Identify the index of the next requirement to fulfill, choosing the hardest neccessary requirement out of the most easiest to enroll requirements
 const calculateIndexOfNextReqToAdd = (
   reqList,
-  kernelDepthCourses,
   timetableCourses,
   totalReqNeeded
 ) => {
-  let currentTimetableCourseIds = findIdSetOfCoursesInTimetable(
-    kernelDepthCourses,
-    timetableCourses
-  );
+  let currentTimetableCourseIds =
+    findIdSetOfCoursesInTimetable(timetableCourses);
   let reqLeftToFulfill =
     totalReqNeeded -
     reqList.filter((req) => currentTimetableCourseIds.has(req.id)).length;
@@ -933,7 +958,6 @@ const isRequirementsPlacedInTimetable = (
 
   let currentReqIndex = calculateIndexOfNextReqToAdd(
     scoredReqList,
-    kernelDepthCourses,
     timetableCourses,
     totalReqAmount
   );
@@ -941,10 +965,8 @@ const isRequirementsPlacedInTimetable = (
   // Filter for the top easiest-to-fulfill prerequisites/corequisites needed, then given these requirements, fulfill the hardest neccessary requirement first,
   // working towards the easiest to enroll requirement
   while (currentReqIndex >= 0) {
-    let currentTimetableCourseIds = findIdSetOfCoursesInTimetable(
-      kernelDepthCourses,
-      timetableCourses
-    );
+    let currentTimetableCourseIds =
+      findIdSetOfCoursesInTimetable(timetableCourses);
     let remainingScoredReq = scoredReqList.filter(
       (req) => !currentTimetableCourseIds.has(req.id)
     );
@@ -966,7 +988,6 @@ const isRequirementsPlacedInTimetable = (
 
     currentReqIndex = calculateIndexOfNextReqToAdd(
       scoredReqList,
-      kernelDepthCourses,
       timetableCourses,
       totalReqAmount
     );
@@ -975,7 +996,6 @@ const isRequirementsPlacedInTimetable = (
   if (
     calculateIndexOfNextReqToAdd(
       originalReqList,
-      kernelDepthCourses,
       timetableCourses,
       totalReqAmount
     ) >= 0
@@ -1105,7 +1125,11 @@ const updateOffsets = (
   }
 };
 
-export const isThereValidCombination = (areaCourseLists, timetable, usedCourseIds) => {
+export const isThereValidCombination = (
+  areaCourseLists,
+  timetable,
+  usedCourseIds
+) => {
   for (const areaCourseList of areaCourseLists) {
     let sortedCourseList = areaCourseList.courses.toSorted(
       (crsA, crsB) =>
@@ -1641,11 +1665,17 @@ export const generateTimetable = async (
   if (!ece472Id) throw new Error(RETRIEVING_472_ERROR);
 
   const shoppingCartCourses = await Course.findCoursesInCart(userId);
-  if (shoppingCartCourses.length < MINIMUM_COURSES)
+  if (
+    !shoppingCartCourses ||
+    shoppingCartCourses.length < MINIMUM_COURSES_BEFORE_472
+  )
     throw new Error(NOT_ENOUGH_COURSES_ERROR);
   const refinedShoppingCart =
     filterOutCoursesNotMeetingRequirements(shoppingCartCourses);
-  if (refinedShoppingCart.length < MINIMUM_COURSES)
+  if (
+    !refinedShoppingCart ||
+    refinedShoppingCart.length < MINIMUM_COURSES_BEFORE_472
+  )
     throw new Error(NOT_ENOUGH_COURSES_AFTER_REFINING_ERROR);
 
   // Store recommendation scores for all courses in refined cart (to be used in timetable ranking logic)
@@ -1777,7 +1807,9 @@ export const generateTimetable = async (
           isExploringMajorPermutations,
           topCombinationIndex,
           currentFailedAttempts,
-          maximumFailedAttemptsWithRandomOffset
+          maximumFailedAttemptsWithRandomOffset,
+          areaCourseLists,
+          timetable.depth
         ) ||
         !findTopTimetable(
           kernelDepthCourses,
@@ -1859,7 +1891,8 @@ export const generateTimetable = async (
     case 0:
       throw new Error(
         NO_TIMETABLE_POSSIBLE +
-          (anyDepth && !anyKernelDepth ? CONSIDER_ANY_KERNEL_DEPTH_MESSAGE : "")
+          (anyDepth && !anyKernelDepth ? CONSIDER_ANY_KERNEL_DEPTH_MESSAGE : "") +
+          (duration < MAXIMUM_DURATION ? CONSIDER_INCREASING_DURATION : "")
       );
     default:
       if (

--- a/frontend/src/components/Timetable.jsx
+++ b/frontend/src/components/Timetable.jsx
@@ -23,6 +23,7 @@ import {
   SELECT_PATH,
   TIMETABLE_AREAS_CHANGE_TITLE,
   UPDATE_AREAS_PATH,
+  MAXIMUM_DURATION,
 } from "../utils/constants";
 import { fetchCoursesInCart } from "../utils/fetchShoppingCart";
 import ExploreCourse from "./exploreCourseList/ExploreCourse";
@@ -43,6 +44,7 @@ const Timetable = () => {
     { title: "4th Year, Winter", courses: Array(5).fill(null) },
   ];
   const DEFAULT_DURATION = 5;
+  const MINIMUM_DURATION = 1;
 
   const navigate = useNavigate();
   const infoRef = useRef();
@@ -933,8 +935,8 @@ const Timetable = () => {
               </span>
               <Slider
                 defaultValue={DEFAULT_DURATION}
-                min={1}
-                max={30}
+                min={MINIMUM_DURATION}
+                max={MAXIMUM_DURATION}
                 valueLabelDisplay="auto"
                 onChange={(event) =>
                   setGenerateTimetableDuration(event.target.value)

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -459,3 +459,5 @@ export const ECE472_CODE = "ECE472H1";
 
 export const TIMETABLE_AREAS_CHANGE_TITLE =
   "To Proceed, Timetable Areas Must Change";
+
+export const MAXIMUM_DURATION = 30;


### PR DESCRIPTION
**In this PR, I completed the following**

- Implement 4 Jest tests, covering validity of returned timetable data, accuracy of 2 helper functions, and completeness of recursive logic to add a course & all of its nested requirements to the timetable; The results of both testing suites (for TC 1 & 2) are found below
<img width="421" height="184" alt="Screenshot 2025-07-22 at 5 15 38 PM" src="https://github.com/user-attachments/assets/a95be8a4-45a6-4174-bef4-0715b3ce6b92" />

- Implement bugfixes & refactoring based on both PR feedback, testing done, and dogfooding with other interns: [Dogfooding Document](https://docs.google.com/document/d/152xFvYA_Uhhjpq9BB9sp6TQd4bQBdyxxF9NJNwZUoJE/edit?tab=t.0
)

**Edge/error cases handled + tests done** 

- Course ID passed to function responsible for adding courses to timetable is invalid - add a null check to avoid trying to use the resulting undefined course object
- Courses such as ECE427, ECE417, ECE526 & ECE444 are being placed in first term yet they have prerequisites to be met, resulting in errors within the returned timetables - Handled by ensuring all prerequisites are added if they are not already added to the timetable, instead of checking for if they are either already found in the timetable or found in the kernel/depth course list (doing this caused prerequisites to be skipped over until it was too late & the course needing these prerequisites was placed in the 1st term)
- Total courses beyond 8 that could contribute to kernel areas is under 3 (total kernel courses - 8 < 3): Modify isCombinationValid function to ignore the rule that each major kernel/depth course combination must have 3+ course differences, given this would not be possible
- Create new timetable redirects user to wrong timetable - modify Prisma call to order timetable IDs from least to greatest to ensure the latest timetable ID is correctly identified & returned in the URL redirect
- Test against very small shopping carts where just enough courses are valid (exactly 20) & where 1 or 2 extra kernel/depth courses are added (so ~21-23 courses total) to enable greater variations - produces valid timetable outputs with all requirements are met, in the cases of sticking to the existing kernel/depth areas, allowing any kernel/depth areas, and allowing only different depth areas; Documented one of the several valid test cases attempted, as shown below
<img width="500" height="800" alt="Screenshot 2025-07-22 at 9 43 48 PM" src="https://github.com/user-attachments/assets/a1521065-e1b0-48e6-a31d-f5342def2ff9" />

- Repeat the process for invalid shopping carts (e.g. 1 course off in a specific kernel/depth area from being valid such that too many courses are added in some areas but not enough in others) - produces error messages, with suggestions on potential actions to take to produce a valid output (e.g. increase duration, if not maxed out, to potentially retrieve a valid timetable, as shown below) 
<img width="1689" height="858" alt="Screenshot 2025-07-22 at 9 46 53 PM" src="https://github.com/user-attachments/assets/9a1556a1-bbc5-471a-ad16-44b258b6d614" />

- 2 courses are corequisites to each other & call easy to enroll score - avoid identifying there to be 2 more courses to enroll in rather than 1 within the recursive call. when looking at the course's corequisite (which has a corequisite that is the calling course itself), do not consider that course itself as an unmet requirement
- Ensure prerequisites do not form a loop (causing an infinite recursive call when trying to add a course & its requirements to the timetable) - not possible, given all courses have prerequisites that are fundamental courses with no further requirements, or if its prerequisites do have more prerequisites, they are for fundamental courses
- Tested different time durations combined with different checkbox statuses (do/do not consider any kernel/depth area, do/do not consider any depth area) - valid timetable produced in all scenarios with enough courses


<div>
    <a href="https://www.loom.com/share/e4a1b03b78a148baab49cf356d6726e0">
      <p>Example frontend test case (displaying descriptive error messaging for an invalid case then how it becomes valid after enabling any kernel/depth areas)</p>
    </a>
    <a href="https://www.loom.com/share/e4a1b03b78a148baab49cf356d6726e0">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/e4a1b03b78a148baab49cf356d6726e0-155ee74668f1a216-full-play.gif">
    </a>
  </div>