### PR TITLE
Implement heaviness scoring & overloaded course option scoring

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,6 +19,7 @@
         "express": "^5.1.0",
         "express-session": "^1.18.1",
         "helmet": "^8.1.0",
+        "mathjs": "^14.6.0",
         "morgan": "^1.10.0",
         "ts-jest": "^29.4.0"
       },
@@ -1625,6 +1626,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
+      "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -3269,6 +3279,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/complex.js": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.4.2.tgz",
+      "integrity": "sha512-qtx7HRhPGSCBtGiST4/WGHuW+zeaND/6Ld+db6PbrulIB1i2Ev/2UPiqcmpQNPSyfBKraC0EOvOKCB5dGZKt3g==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3376,6 +3399,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "1.6.0",
@@ -3580,6 +3609,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/escape-latex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
+      "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw==",
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
@@ -3917,6 +3952,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.2.2.tgz",
+      "integrity": "sha512-uXBDv5knpYmv/2gLzWQ5mBHGBRk9wcKTeWu6GLTUEQfjCxO09uM/mHDrojlL+Q1mVGIIFo149Gba7od1XPgSzQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fresh": {
@@ -4438,6 +4486,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+      "license": "MIT"
     },
     "node_modules/jest": {
       "version": "30.0.4",
@@ -5172,6 +5226,29 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mathjs": {
+      "version": "14.6.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-14.6.0.tgz",
+      "integrity": "sha512-5vI2BLB5GKQmiSK9BH6hVkZ+GgqpdnOgEfmHl7mqVmdQObLynr63KueyYYLCQMzj66q69mV2XZZGQqqxeftQbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.26.10",
+        "complex.js": "^2.2.5",
+        "decimal.js": "^10.4.3",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^5.2.1",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^4.2.1"
+      },
+      "bin": {
+        "mathjs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/media-typer": {
@@ -5951,6 +6028,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -6419,6 +6502,12 @@
         "node": "*"
       }
     },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "license": "MIT"
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -6562,6 +6651,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/typed-function": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.2.1.tgz",
+      "integrity": "sha512-EGjWssW7Tsk4DGfE+5yluuljS1OGYWiI1J6e8puZz9nTMM51Oug8CD5Zo4gWMsOhq5BI+1bF+rWTm4Vbj3ivRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/typescript": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,6 +28,7 @@
     "express": "^5.1.0",
     "express-session": "^1.18.1",
     "helmet": "^8.1.0",
+    "mathjs": "^14.6.0",
     "morgan": "^1.10.0",
     "ts-jest": "^29.4.0"
   },

--- a/backend/utils/requirementCheckHelpers.js
+++ b/backend/utils/requirementCheckHelpers.js
@@ -2,7 +2,7 @@ import {
   ECE472_CODE,
   initialErrors,
   OVERLOADED_POSITION,
-  KERNEL_DEPTH_COURSES_NEEDED
+  KERNEL_DEPTH_COURSES_NEEDED,
 } from "../../frontend/src/utils/constants.js";
 import {
   initializeAreaCoursesList,
@@ -34,6 +34,12 @@ const createCourseObject = (currentCourseObject, newCourse) => {
     ...currentCourseObject,
     course: generateCourseString(newCourse),
   };
+};
+
+export const findNonOverloadedCourses = (courses) => {
+  return courses.filter(
+    (courseObject) => courseObject.position !== OVERLOADED_POSITION
+  );
 };
 
 export const checkForPrereqErrors = (errorsObject, courses) => {
@@ -123,9 +129,7 @@ export const checkForExclusionErrors = (errorsObject, courses) => {
 };
 
 export const isValidIgnoringOverloaded = (timetable) => {
-  let nonOverloadedCourses = timetable.courses.filter(
-    (courseObject) => courseObject.position !== OVERLOADED_POSITION
-  );
+  let nonOverloadedCourses = findNonOverloadedCourses(timetable.courses);
 
   let errorObjectList = structuredClone(initialErrors);
   checkForPrereqErrors(errorObjectList, nonOverloadedCourses);

--- a/frontend/src/components/Timetable.jsx
+++ b/frontend/src/components/Timetable.jsx
@@ -27,7 +27,7 @@ import {
   MAXIMUM_DURATION,
   OVERLOAD_PATH,
   OVERLOADED_POSITION,
-  CONFLICTING_TIMETABLE_ERROR
+  CONFLICTING_TIMETABLE_ERROR,
 } from "../utils/constants";
 import { fetchCoursesInCart } from "../utils/fetchShoppingCart";
 import ExploreCourse from "./exploreCourseList/ExploreCourse";
@@ -36,7 +36,10 @@ import { areRequirementsMet } from "../utils/requirementsCheck";
 import { updateCoursesInCart } from "../utils/updateCourses";
 import { Slider, Checkbox } from "@mui/material";
 import ErrorModal from "./errorModal/ErrorModal";
-import { isValidIgnoringOverloaded } from "../../../backend/utils/requirementCheckHelpers";
+import {
+  findNonOverloadedCourses,
+  isValidIgnoringOverloaded,
+} from "../../../backend/utils/requirementCheckHelpers";
 
 const Timetable = () => {
   const OVERLOADED_COURSES_TITLE = "Overloaded Courses";
@@ -1235,9 +1238,11 @@ const Timetable = () => {
       <ErrorModal
         title={PLAN_COURSES_TO_OVERLOAD}
         message={null}
-        timetableCourses={timetable?.courses?.filter(
-          (courseObject) => courseObject.position !== OVERLOADED_POSITION
-        )}
+        timetableCourses={
+          timetable?.courses
+            ? findNonOverloadedCourses(timetable.courses)
+            : null
+        }
         coursesInCart={coursesInCart}
         coursesPlanToOverload={coursesPlanToOverload}
         setCoursesPlanToOverload={setCoursesPlanToOverload}

--- a/frontend/src/components/currentTimetablesList/CurrentTimetablesList.jsx
+++ b/frontend/src/components/currentTimetablesList/CurrentTimetablesList.jsx
@@ -1,3 +1,4 @@
+import { findNonOverloadedCourses } from "../../../../backend/utils/requirementCheckHelpers.js";
 import { OVERLOADED_POSITION } from "../../utils/constants.js";
 import CurrentTimetable from "./CurrentTimetable.jsx";
 
@@ -14,9 +15,7 @@ const CurrentTimetablesList = (props) => {
             <CurrentTimetable
               key={index}
               timetable={timetable}
-              notOverloadedCourses={timetable?.courses?.filter(
-                (course) => course.position !== OVERLOADED_POSITION
-              )}
+              notOverloadedCourses={timetable?.courses ? findNonOverloadedCourses(timetable.courses) : null}
               overloadedCourses={timetable?.courses?.filter(
                 (course) => course.position === OVERLOADED_POSITION
               )}

--- a/frontend/src/utils/requirementsCheck.js
+++ b/frontend/src/utils/requirementsCheck.js
@@ -16,6 +16,7 @@ import {
   checkForPrereqErrors,
   findNonDepthKernelAreaCourses,
   findDepthKernelAreaCourses,
+  findNonOverloadedCourses,
 } from "../../../backend/utils/requirementCheckHelpers.js";
 
 const checkDesignation = (
@@ -56,9 +57,7 @@ export const areRequirementsMet = (
   let depthCourses = [];
 
   initializeAreaCoursesList(areaCoursesList, timetable.kernel);
-  let nonOverloadedCourses = timetable.courses.filter(
-    (courseObject) => courseObject.position !== OVERLOADED_POSITION
-  );
+  let nonOverloadedCourses = findNonOverloadedCourses(timetable.courses);
   nonOverloadedCourses.forEach((courseObject) => {
     updateAreaCoursesList(courseObject, areaCoursesList);
   });


### PR DESCRIPTION
In this PR, I implemented the following:

- Implement logic to score how heavy each course is by lack of matches between its ECE areas & user's ECE areas, lack of matches between its minors/certificates & those of the user, and z-score (number of standard deviations away from mean) for lecture/tutorial/practical hours & recommended score 
- Implement logic to determine average heaviness score across all non-overloaded courses in current timetable
- Implement weighted scoring logic to rank overloaded course combinations by how imbalanced they are (finding differences between average term heaviness score before considering overloaded courses & the overloaded course's score + differences between average timetable heaviness score & each term's average score after considering overloaded courses)

Key Notes

- Implement refactoring of repeated tasks (e.g. finding non-overloaded courses given a list of timetable courses)
- Imported library to handle standard deviation task - mathjs

Backend/Edge Test Cases - identical test suite to [last PR](https://github.com/CourseCompass-ECE/course-compass/pull/41) with added check for valid scoring between 70% & 100% (in order from greatest to least)

<div>
    <a href="https://www.loom.com/share/03967e40622c410f9e75a8557980df53">
      <p>Frontend Walkthrough + Test Cases Demonstration</p>
    </a>
    <a href="https://www.loom.com/share/03967e40622c410f9e75a8557980df53">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/03967e40622c410f9e75a8557980df53-9cf28f0117265c35-full-play.gif">
    </a>
  </div>