### PR TITLE
Implement TCs 1, 2, and stretch features PR feedback

### DIFF
--- a/backend/utils/findOverloadedCourses.js
+++ b/backend/utils/findOverloadedCourses.js
@@ -195,7 +195,8 @@ const isCurrentTermInvalid = (
   for (const [courseOptionIndex, courseOption] of courseOptions
     .filter((_, index) => index < currentCourseIndex)
     .entries()) {
-    if (courseOption.prereqOptions) { // courseOption is course of focus
+    if (courseOption.prereqOptions) {
+      // courseOption is course of focus
       // Find other already added overloaded courses that are placed in a term prior to the current overloaded course of focus & are part of the course's
       // prerequisites list
       let prereqMetAlreadyFromOtherOverloaded = 0;
@@ -212,9 +213,7 @@ const isCurrentTermInvalid = (
       });
 
       // Number of prerequisites still needing to be met by remaining overloaded courses not already added in a specific term
-      let remainderPrereqCount =
-        courseOption.course.prerequisiteAmount -
-        prereqMetAlreadyFromOtherOverloaded -
+      let nonOverloadedCoursesMeetingPrereq =
         findNonOverloadedCoursesMeetingPrereq(
           currentTermsUsed[courseOptionIndex],
           new Set(
@@ -222,6 +221,10 @@ const isCurrentTermInvalid = (
           ),
           nonOverloadedCourses
         );
+      let remainderPrereqCount =
+        courseOption.course.prerequisiteAmount -
+        prereqMetAlreadyFromOtherOverloaded -
+        nonOverloadedCoursesMeetingPrereq;
 
       if (remainderPrereqCount <= 0) continue;
       else if (remainderPrereqCount > prereqLeft.size) return true;
@@ -545,7 +548,13 @@ export const findOverloadedCourses = async (userId, courseIds, timetableId) => {
   });
 
   let nonOverloadedCourses = findNonOverloadedCourses(timetable.courses);
-  let validOptions = findValidOptions(courseOptions, [], 0, [], nonOverloadedCourses);
+  let validOptions = findValidOptions(
+    courseOptions,
+    [],
+    0,
+    [],
+    nonOverloadedCourses
+  );
   if (validOptions.length === 0) throw new Error(REQUIREMENTS_CONFLICT);
 
   let nonOverloadedTimetableCourseIdsSet = new Set(

--- a/backend/utils/findRecommendedCourses.js
+++ b/backend/utils/findRecommendedCourses.js
@@ -449,11 +449,11 @@ export const findMatchesToRelatedUsersCourses = async (
         (course) => course.id === cartCourse.id
       );
       if (courseMatchingOtherUserCart) {
+        let foundInFavoritesMultiplier = favoriteIdList.has(cartCourse.id)
+          ? FAVORITED_CART_COURSE_MULTIPLER
+          : 1;
         courseMatchingOtherUserCart.score +=
-          COURSE_LIKED_ACROSS_SIMILAR_USERS *
-          (favoriteIdList.has(cartCourse.id)
-            ? FAVORITED_CART_COURSE_MULTIPLER
-            : 1);
+          COURSE_LIKED_ACROSS_SIMILAR_USERS * foundInFavoritesMultiplier;
       }
     });
 
@@ -644,7 +644,8 @@ export const findRecommendedCourses = async (
 
   scoreCoursesAgainstUser(coursesWithScores, user);
 
-  // If more than two times the rolling average worth of courses are present (and not scoring courses for the purpose of timetable ranking), filter them down
+  // If equal/more than two times the rolling average worth of courses are present (and not scoring courses for the purpose of 
+  // timetable ranking), filter them down
   if (
     coursesWithScores.length >= NUM_COURSES_ROLLING_AVERAGE * 2 &&
     !isRankingTimetableCourses

--- a/frontend/src/components/CreateAccount.jsx
+++ b/frontend/src/components/CreateAccount.jsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
-import CreateAccountStepOne from "./createAccountSteps/CreateAccountStepOne";
-import CreateAccountStepTwo from "./createAccountSteps/CreateAccountStepTwo";
-import CreateAccountStepThree from "./createAccountSteps/CreateAccountStepThree";
-import CreateAccountStepFour from "./createAccountSteps/CreateAccountStepFour";
-import CreateAccountStepFive from "./createAccountSteps/CreateAccountStepFive";
-import CreateAccountStepSix from "./createAccountSteps/CreateAccountStepSix";
+import CreateAccountStepOneLoginInfo from "./createAccountSteps/CreateAccountStepOneLoginInfo";
+import CreateAccountStepTwoPfp from "./createAccountSteps/CreateAccountStepTwoPfp";
+import CreateAccountStepThreeResume from "./createAccountSteps/CreateAccountStepThreeResume";
+import CreateAccountStepFourSkillsInterests from "./createAccountSteps/CreateAccountStepFourSkillsInterests";
+import CreateAccountStepFiveMinorsCerts from "./createAccountSteps/CreateAccountStepFiveMinorsCerts";
+import CreateAccountStepSixLearningGoal from "./createAccountSteps/CreateAccountStepSixLearningGoal";
 
 const CreateAccount = () => {
   const [currentStep, setCurrentStep] = useState(1);
@@ -36,7 +36,7 @@ const CreateAccount = () => {
     switch (currentStep) {
       case 1:
         return (
-          <CreateAccountStepOne
+          <CreateAccountStepOneLoginInfo
             fullName={fullName}
             setFullName={setFullName}
             email={email}
@@ -49,7 +49,7 @@ const CreateAccount = () => {
         );
       case 2:
         return (
-          <CreateAccountStepTwo
+          <CreateAccountStepTwoPfp
             setCurrentStep={setCurrentStep}
             currentStep={currentStep}
             pfp={pfp}
@@ -60,7 +60,7 @@ const CreateAccount = () => {
         );
       case 3:
         return (
-          <CreateAccountStepThree
+          <CreateAccountStepThreeResume
             setCurrentStep={setCurrentStep}
             currentStep={currentStep}
             setResume={setResume}
@@ -74,7 +74,7 @@ const CreateAccount = () => {
         );
       case 4:
         return (
-          <CreateAccountStepFour
+          <CreateAccountStepFourSkillsInterests
             setCurrentStep={setCurrentStep}
             currentStep={currentStep}
             eceAreas={eceAreas}
@@ -87,7 +87,7 @@ const CreateAccount = () => {
         );
       case 5:
         return (
-          <CreateAccountStepFive
+          <CreateAccountStepFiveMinorsCerts
             setCurrentStep={setCurrentStep}
             currentStep={currentStep}
             desiredDesignation={desiredDesignation}
@@ -100,7 +100,7 @@ const CreateAccount = () => {
         );
       case 6:
         return (
-          <CreateAccountStepSix
+          <CreateAccountStepSixLearningGoal
             fullName={fullName}
             email={email}
             password={password}

--- a/frontend/src/components/createAccountSteps/CreateAccountStepFiveMinorsCerts.jsx
+++ b/frontend/src/components/createAccountSteps/CreateAccountStepFiveMinorsCerts.jsx
@@ -8,7 +8,7 @@ import {
 import RenderDropdownMenu from "../../utils/renderDropdown";
 import CreateAccountButton from "./CreateAccountButton";
 
-const CreateAccountStepFive = (props) => {
+const CreateAccountStepFiveMinorsCerts = (props) => {
   const [desiredDesignationError, setDesiredDesignationError] = useState("");
   const [desiredMinorsError, setDesiredMinorsError] = useState("");
   const [desiredCertificatesError, setDesiredCertificatesError] = useState("");
@@ -103,4 +103,4 @@ const CreateAccountStepFive = (props) => {
   );
 };
 
-export default CreateAccountStepFive;
+export default CreateAccountStepFiveMinorsCerts;

--- a/frontend/src/components/createAccountSteps/CreateAccountStepFourSkillsInterests.jsx
+++ b/frontend/src/components/createAccountSteps/CreateAccountStepFourSkillsInterests.jsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import RenderDropdownMenu from "../../utils/renderDropdown";
 import CreateAccountButton from "./CreateAccountButton";
 
-const CreateAccountStepFour = (props) => {
+const CreateAccountStepFourSkillsInterests = (props) => {
   const [eceAreasError, setEceAreasError] = useState("");
   const [interestsError, setInterestsError] = useState("");
   const [skillsError, setSkillsError] = useState("");
@@ -88,4 +88,4 @@ const CreateAccountStepFour = (props) => {
   );
 };
 
-export default CreateAccountStepFour;
+export default CreateAccountStepFourSkillsInterests;

--- a/frontend/src/components/createAccountSteps/CreateAccountStepOneLoginInfo.jsx
+++ b/frontend/src/components/createAccountSteps/CreateAccountStepOneLoginInfo.jsx
@@ -10,7 +10,7 @@ import {
 import CreateAccountButton from "./CreateAccountButton";
 import { EMAIL_ERROR, CONTINUE } from "../../utils/constants";
 
-const CreateAccountStepOne = (props) => {
+const CreateAccountStepOneLoginInfo = (props) => {
   const [fullNameError, setFullNameError] = useState("");
   const [emailError, setEmailError] = useState("");
   const [passwordError, setPasswordError] = useState("");
@@ -159,4 +159,4 @@ const CreateAccountStepOne = (props) => {
   );
 };
 
-export default CreateAccountStepOne;
+export default CreateAccountStepOneLoginInfo;

--- a/frontend/src/components/createAccountSteps/CreateAccountStepSixLearningGoal.jsx
+++ b/frontend/src/components/createAccountSteps/CreateAccountStepSixLearningGoal.jsx
@@ -32,7 +32,7 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 const storage = getStorage(app);
 
-const CreateAccountStepSix = (props) => {
+const CreateAccountStepSixLearningGoal = (props) => {
   const navigate = useNavigate();
   const [learningGoalError, setLearningGoalError] = useState("");
   const [submissionError, setSubmissionError] = useState("");
@@ -461,4 +461,4 @@ const CreateAccountStepSix = (props) => {
   );
 };
 
-export default CreateAccountStepSix;
+export default CreateAccountStepSixLearningGoal;

--- a/frontend/src/components/createAccountSteps/CreateAccountStepThreeResume.jsx
+++ b/frontend/src/components/createAccountSteps/CreateAccountStepThreeResume.jsx
@@ -10,7 +10,7 @@ import {
 } from "../../utils/resumeHelperFunctions";
 import ParsingLoader from "./ParsingLoader";
 
-const CreateAccountStepThree = (props) => {
+const CreateAccountStepThreeResume = (props) => {
   const [resumeError, setResumeError] = useState("");
   const [isLoadingDocx, setIsLoadingDocx] = useState(false);
   const fileInputRef = useRef();
@@ -184,4 +184,4 @@ const CreateAccountStepThree = (props) => {
   );
 };
 
-export default CreateAccountStepThree;
+export default CreateAccountStepThreeResume;

--- a/frontend/src/components/createAccountSteps/CreateAccountStepTwoPfp.jsx
+++ b/frontend/src/components/createAccountSteps/CreateAccountStepTwoPfp.jsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import CreateAccountButton from "./CreateAccountButton";
 import { CONTINUE } from "../../utils/constants";
 
-const CreateAccountStepTwo = (props) => {
+const CreateAccountStepTwoPfp = (props) => {
   const [pfpError, setPfpError] = useState("");
   const STEP_TITLE = "Add a Profile Picture";
   const PFP_ALT = "User's profile picture";
@@ -74,4 +74,4 @@ const CreateAccountStepTwo = (props) => {
   );
 };
 
-export default CreateAccountStepTwo;
+export default CreateAccountStepTwoPfp;


### PR DESCRIPTION
In this PR, I completed the following

- Implement feedback from PR #22 onwards, refactoring code, clarifying variable & component names, and implementing comments for increased readability & DRY-ness
- Implement modifications to overloading timetable logic to explore valid combinations where even though nonoverloaded timetable courses can meet the prerequisite requirements of overloaded courses, it will look at combinations where other overloaded courses are meeting these requirements (initially only did this when it was mandatory to explore other prereq options given not enough prereqs were found among nonoverloaded courses)

Key Notes

- Renaming & refactoring is done to break up large & potentially hard to read chunks of codes/individual lines to increase readability + reduce error-prone code

Edge Cases/Test Cases

- TC 1/resume stretch: Creating new user with mainly Computer Engineering related preferences (minors/certificates, areas, skills, interests are related to Computer Engineering) - successfully creates user & stores resume/profile photo, then receive recommended courses where most highly rated ones are Computer Engineering-related
- TC 1: Reject several courses related to Electrical Engineering, while adding to favorites/cart mainly Computer Engineering courses - next set of recommended courses mainly pertain to Computer Engineering
- TC 2: After setting timetable kernel/depth area preferences to 2 Computer areas (depth kernel areas) & 2 Electrical areas (non-depth kernel areas), generate timetable for 10 seconds - takes 10 seconds, then returns 3 valid combinations with at least 3 courses in the depth areas & 1 in the non-depth areas
- TC 2: After activating any kernel/depth area & setting duration to 20 seconds, click generate timetable - takes full 20 seconds & returns 3 valid timetables with at least 3 courses in 2 depth areas & 1 in 2 non-depth areas, then after accepting a timetable, a pop-up appears warning about the change in kernel/depth areas if they differ from current timetable's config
- Overloaded stretch: With valid timetable containing ECE302 in 1st term & ECE313 in 2nd term, attempt to overload with ECE349 & ECE526 (prereq = 1 needed from 314, 349, 313) - provides 3 combinations where ECE526 meets requirement from either 313 in 2nd term (being placed in 3rd or 4th term) or from 349 (by placing 349 in 1st term & 526 in 2nd)
- Overloaded stretch: With valid timetable containing ECE302 in 1st term & ECE316 in 2nd term, attempt to overload with ECE464 (prereq = 2 needed from 302, 417, 316) & ECE417 (prereq = 302, 316) - receive 2 valid combinations with courses in 3rd & 4th terms
- Overloaded stretch: With valid timetable containing ECE302 in 1st term, attempt to overload with ECE361 (coreq = ECE302) - returns 1 combination where 361 is placed in 1st term **(demonstrated in frontend video)**
- Overloaded stretch: 1, 2, and 3 options returned - arrows enable navigation from 1st option to last, with different banner color & new combination rendered with its score for each (handles edge case with only 1 option where min-max normalization fails)

<div>
    <a href="https://www.loom.com/share/ff627f399dfb483a96786511d9c76059">
      <p>Test Case Walkthrough - Overloaded Stretch Case </p>
    </a>
    <a href="https://www.loom.com/share/ff627f399dfb483a96786511d9c76059">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/ff627f399dfb483a96786511d9c76059-6b179cf800d5117e-full-play.gif">
    </a>
  </div>